### PR TITLE
Drb

### DIFF
--- a/lib/guard/rspec.rb
+++ b/lib/guard/rspec.rb
@@ -7,6 +7,11 @@ module Guard
     autoload :Runner, 'guard/rspec/runner'
     autoload :Inspector, 'guard/rspec/inspector'
     
+    def initialize(watchers = [], options = {})
+      super
+      Runner.use_drb(options)
+    end
+
     def start
       Runner.set_rspec_version(options)
     end

--- a/lib/guard/rspec/runner.rb
+++ b/lib/guard/rspec/runner.rb
@@ -3,22 +3,31 @@ module Guard
     module Runner
       class << self
         attr_reader :rspec_version
-        
+
         def run(paths, options = {})
           message = options[:message] || "Running: #{paths.join(' ')}"
           UI.info message, :reset => true
           system(rspec_command(paths))
         end
-        
+
         def set_rspec_version(options = {})
           @rspec_version = options[:version] || determine_rspec_version
         end
-        
+
+        def use_drb(options = {})
+          @use_drb = options[:drb] == true
+        end
+
+        def using_drb?
+          @use_drb
+        end
+
       private
-        
+
         def rspec_command(paths)
           cmd_parts = []
           cmd_parts << "bundle exec" if bundler?
+
           case rspec_version
           when 1
             cmd_parts << "spec"
@@ -27,15 +36,18 @@ module Guard
             cmd_parts << "rspec"
             cmd_parts << "--require #{File.dirname(__FILE__)}/formatters/rspec_notify.rb --format RSpecNotify"
           end
+
+          cmd_parts << "--drb" if using_drb?
           cmd_parts << "--color"
+
           cmd_parts << paths.join(' ')
           cmd_parts.join(" ")
         end
-        
+
         def bundler?
           @bundler ||= File.exist?("#{Dir.pwd}/Gemfile")
         end
-        
+
         def determine_rspec_version
           UI.info "Determine rspec_version... (can be forced with Guard::RSpec version option)"
           if File.exist?("#{Dir.pwd}/spec/spec_helper.rb")
@@ -48,7 +60,7 @@ module Guard
             2
           end
         end
-        
+
       end
     end
   end

--- a/spec/guard/rspec/runner_spec.rb
+++ b/spec/guard/rspec/runner_spec.rb
@@ -1,8 +1,20 @@
 require 'spec_helper'
 
 describe Guard::RSpec::Runner do
-  subject { Guard::RSpec::Runner}
-  
+  subject { Guard::RSpec::Runner }
+
+  describe 'using_drb?' do
+    it 'is true when DRB options is true' do
+      subject.use_drb({:drb => true})
+      subject.should be_using_drb
+    end
+
+    it 'is false when the DRB option is anything but true' do
+      subject.use_drb({:drb => 'strawberry jam'})
+      subject.should_not be_using_drb
+    end
+  end
+
   describe "run" do
     
     context "in empty folder" do

--- a/spec/guard/rspec_spec.rb
+++ b/spec/guard/rspec_spec.rb
@@ -2,7 +2,14 @@ require 'spec_helper'
 
 describe Guard::RSpec do
   subject { Guard::RSpec.new }
-  
+
+  describe '#initialize' do
+    it 'should pass options to the Runner.use_drb' do
+      Guard::RSpec::Runner.should_receive(:use_drb).with({:drb => true})
+      Guard::RSpec.new([], {:drb => true})
+    end
+  end
+
   describe "start" do
     it "should set rspec_version" do
       Guard::RSpec::Runner.should_receive(:set_rspec_version)


### PR DESCRIPTION
I couldn't see any support for using `--drb` with a Rails project and figured being abe to pass an option in the Guardfile in order to use `--drb` might be nice.

Not sure if you'll like the way I've done it. I'm not a fan of the `#use_drb` method's name or how it takes all options but I tried to use a similar approach to the one used elsewhere. I think it might be nicer to use a writer and call `Runner.use_drb = !!options[:drb]`.

Guard rocks.

P.S. I've just noticed there's a spec failure in the Runner spec.

```
Failures:
  1) Guard::RSpec::Runner set_rspec_version in RSpec 1 with bundler only folder should set RSpec 1 from Bundler
     Failure/Error: subject.rspec_version.should == 1
     expected: 1,
          got: 2 (using ==)
     # ./spec/guard/rspec/runner_spec.rb:59:in `block (4 levels) in <top (required)>'

Finished in 0.9966 seconds
8 examples, 1 failure
```

I'm running `ruby 1.9.2p0`.
