### PR TITLE
Deprecated guardfile syntax

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,5 +1,5 @@
 guard 'rspec', :version => 2, :formatter => "instafail" do
-  watch('^spec/(.*)_spec.rb')
-  watch('^lib/(.*).rb')          { |m| "spec/#{m[1]}_spec.rb" }
-  watch('^spec/spec_helper.rb')  { "spec" }
+  watch(%r{spec/(.*)_spec\.rb})
+  watch(%r{lib/(.*)\.rb})       { |m| "spec/#{m[1]}_spec.rb" }
+  watch('spec/spec_helper.rb')  { "spec" }
 end

--- a/lib/guard/rspec/templates/Guardfile
+++ b/lib/guard/rspec/templates/Guardfile
@@ -1,10 +1,10 @@
 guard 'rspec', :version => 2 do
-  watch(%r{spec/(.*)_spec.rb})
+  watch(%r{spec/(.*)_spec\.rb})
   watch(%r{lib/(.*)\.rb})      { |m| "spec/lib/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb') { "spec" }
   
   # Rails example
-  watch(%r{spec/(.*)_spec.rb})
+  watch(%r{spec/(.*)_spec\.rb})
   watch(%r{app/(.*)\.rb})                            { |m| "spec/#{m[1]}_spec.rb" }
   watch(%r{lib/(.*)\.rb})                            { |m| "spec/lib/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb')                       { "spec" }

--- a/spec/fixtures/rspec1/Guardfile
+++ b/spec/fixtures/rspec1/Guardfile
@@ -1,5 +1,5 @@
 guard 'rspec', :version => 1, :formatter => "instafail" do
-  watch('^spec/(.*)_spec.rb')
-  watch('^lib/(.*).rb')          { |m| "spec/#{m[1]}_spec.rb" }
-  watch('^spec/spec_helper.rb')  { "spec" }
+  watch(%r{spec/(.*)_spec\.rb})
+  watch(%r{lib/(.*)\.rb})       { |m| "spec/#{m[1]}_spec.rb" }
+  watch('spec/spec_helper.rb')  { "spec" }
 end

--- a/spec/fixtures/rspec2/Guardfile
+++ b/spec/fixtures/rspec2/Guardfile
@@ -1,5 +1,5 @@
 guard 'rspec', :version => 2 do
-  watch('^spec/(.*)_spec.rb')
-  watch('^lib/(.*).rb')          { |m| "spec/#{m[1]}_spec.rb" }
-  watch('^spec/spec_helper.rb')  { "spec" }
+  watch(%r{spec/(.*)_spec\.rb})
+  watch(%r{lib/(.*)\.rb})        { |m| "spec/#{m[1]}_spec.rb" }
+  watch('spec/spec_helper.rb')    { "spec" }
 end


### PR DESCRIPTION
Fixed the old syntax in the Guardfiles that was generating a deprecation notice when running Guard.
