### PR TITLE
Remove extra whitespace from Guardfile template

### DIFF
--- a/lib/guard/rspec/templates/Guardfile
+++ b/lib/guard/rspec/templates/Guardfile
@@ -2,7 +2,7 @@ guard 'rspec' do
   watch(%r{^spec/.+_spec\.rb})
   watch(%r{^lib/(.+)\.rb})     { |m| "spec/lib/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb') { "spec" }
-  
+
   # Rails example
   watch('spec/spec_helper.rb')                       { "spec" }
   watch('config/routes.rb')                          { "spec/routing" }


### PR DESCRIPTION
I'm a little OCD about having whitespace in my generated files.
