### PR TITLE
Set the priority of the growl notification based on the outcome of the spec run

### DIFF
--- a/lib/guard/rspec/formatter.rb
+++ b/lib/guard/rspec/formatter.rb
@@ -22,8 +22,16 @@ module Formatter
     end
   end
 
+  def priority(image)
+    { :failed => 2,
+      :pending => -1,
+      :success => -2
+    }[image]
+  end
+
   def notify(message, image)
-    Guard::Notifier.notify(message, :title => "RSpec results", :image => image)
+    Guard::Notifier.notify(message, :title => "RSpec results", :image => image,
+      :priority => priority(image))
   end
 
 private


### PR DESCRIPTION
This allows you to set different color notifications in the Growl theme preferences depending on whether the tests passed, are pending, or failed.

It depends on indirect/guard@ae1ae1cfbdf82a4bb2caaa585aecb3f13c7abf82 to be able to pass the :priority option through to the growl notifier.
