### PR TITLE
Undo previous patches (#17)

### DIFF
--- a/lib/guard/rspec/runner.rb
+++ b/lib/guard/rspec/runner.rb
@@ -8,12 +8,7 @@ module Guard
           return false if paths.empty?
           message = options[:message] || "Running: #{paths.join(' ')}"
           UI.info(message, :reset => true)
-
-          success = system(rspec_command(paths, options))
-
-          unless success
-            UI.error("Could not run specs", :reset => true)
-          end
+          system(rspec_command(paths, options))
         end
 
         def set_rspec_version(options={})


### PR DESCRIPTION
I'm sorry, I should have tested this more thoroughly. So much for whipping up a quick fix. :(

Rspec's exit code does not differentiate between a failing spec and failing to run the specs. Kind of obvious in retrospect...
