### PR TITLE
Support for excluding files via an exclude option

### DIFF
--- a/lib/guard/rspec.rb
+++ b/lib/guard/rspec.rb
@@ -17,6 +17,7 @@ module Guard
       @failed_paths = []
 
       Runner.set_rspec_version(options)
+      Inspector.excluded = options[:exclude]
     end
 
     # Call once when guard starts

--- a/lib/guard/rspec/inspector.rb
+++ b/lib/guard/rspec/inspector.rb
@@ -2,17 +2,32 @@ module Guard
   class RSpec
     module Inspector
       class << self
+        def excluded
+          @excluded || []
+        end
+
+        def excluded=(glob)
+          @excluded = Dir[glob.to_s]
+        end
 
         def clean(paths)
           paths.uniq!
           paths.compact!
           clear_spec_files_list_after do
-            paths = paths.select { |p| spec_file?(p) || spec_folder?(p) }
+            paths = paths.select { |path| should_run_spec_file?(path) }
           end
           paths.reject { |p| included_in_other_path?(p, paths) }
         end
 
-      private
+        private
+
+        def should_run_spec_file?(path)
+          (spec_file?(path) || spec_folder?(path)) && !excluded?(path)
+        end
+
+        def excluded?(path)
+          excluded.include?(path)
+        end
 
         def spec_file?(path)
           spec_files.include?(path)
@@ -34,7 +49,6 @@ module Guard
         def included_in_other_path?(path, paths)
           (paths - [path]).any? { |p| path.include?(p) && path.sub(p, '').include?('/') }
         end
-
       end
     end
   end

--- a/spec/guard/rspec/inspector_spec.rb
+++ b/spec/guard/rspec/inspector_spec.rb
@@ -1,8 +1,11 @@
 require 'spec_helper'
 
 describe Guard::RSpec::Inspector do
-
   describe ".clean" do
+    before do
+      subject.excluded = nil
+    end
+
     it "removes non-spec files" do
       subject.clean(["spec/guard/rspec_spec.rb", "bob.rb"]).should == ["spec/guard/rspec_spec.rb"]
     end
@@ -34,6 +37,21 @@ describe Guard::RSpec::Inspector do
     it "removes spec files included in spec folders (2)" do
       subject.clean(["spec/guard/rspec_spec.rb", "spec/guard/rspec/runner_spec.rb", "spec/guard/rspec"]).should == ["spec/guard/rspec_spec.rb", "spec/guard/rspec"]
     end
-  end
 
+    describe 'excluded files' do
+      context 'with a path to a single spec' do
+        it 'ignores the one spec' do
+          subject.excluded = 'spec/guard/rspec_spec.rb'
+          subject.clean(['spec/guard/rspec_spec.rb']).should == []
+        end
+      end
+
+      context 'with a glob' do
+        it 'ignores files recursively' do
+          subject.excluded = 'spec/guard/**/*'
+          subject.clean(['spec/guard/rspec_spec.rb', 'spec/guard/rspec/runner_spec.rb']).should == []
+        end
+      end
+    end
+  end
 end

--- a/spec/guard/rspec_spec.rb
+++ b/spec/guard/rspec_spec.rb
@@ -9,6 +9,11 @@ describe Guard::RSpec do
       Guard::RSpec::Runner.should_receive(:set_rspec_version)
       Guard::RSpec.new
     end
+
+    it 'passes an excluded spec glob to Inspector' do
+      Guard::RSpec::Inspector.should_receive(:excluded=).with('spec/slow/*')
+      Guard::RSpec.new([], :exclude => 'spec/slow/*')
+    end
   end
 
   describe "#start" do


### PR DESCRIPTION
Here's a basic implementation of excluding files in `Guard::RSpec::Inspector`.

``` ruby
guard :rspec, :version => 1, :exclude => 'spec/really_slow_specs/**/*' do
  # …
end
```

I'll close #22 now.
