### PR TITLE
Add :spec_paths option to RSpec::Guard to add additional paths that conta

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ guard 'rspec', :cli => "--color --format nested --fail-fast --drb" do
 end
 ```
 
+By default, Guard::RSpec will only look for spec files within `spec/` in your project root. You can configure Guard::RSpec to look in additional paths by using the `:spec_paths` option:
+
+``` ruby
+guard 'rspec', :spec_paths => ["spec", "vendor/engines/reset/spec"] do
+  # ...
+end
+```
+
 Former `:color`, `:drb`, `:fail_fast` and `:formatter` options are thus deprecated and have no effect anymore.
 
 ### List of available options:
@@ -94,6 +102,7 @@ Former `:color`, `:drb`, `:fail_fast` and `:formatter` options are thus deprecat
 :all_on_start => false       # don't run all the specs at startup, default: true
 :keep_failed => false        # keep failed specs until them pass, default: true
 :run_all => { :cli => "-p" } # override any option when running all specs
+:spec_paths => ["spec/"]     # specify an array of paths that contain spec files
 ```
 
 Notification

--- a/lib/guard/rspec.rb
+++ b/lib/guard/rspec.rb
@@ -11,13 +11,15 @@ module Guard
       @options = {
         :all_after_pass => true,
         :all_on_start   => true,
-        :keep_failed    => true
+        :keep_failed    => true,
+        :spec_paths     => ["spec/"]
       }.update(options)
       @last_failed  = false
       @failed_paths = []
 
       Runner.set_rspec_version(options)
-      Inspector.excluded = options[:exclude]
+      Inspector.excluded = @options[:exclude]
+      Inspector.spec_paths = @options[:spec_paths]
     end
 
     # Call once when guard starts
@@ -27,7 +29,7 @@ module Guard
     end
 
     def run_all
-      passed = Runner.run(["spec/"], options.merge(options[:run_all] || {}).merge(:message => "Running all specs"))
+      passed = Runner.run(options[:spec_paths], options.merge(options[:run_all] || {}).merge(:message => "Running all specs"))
 
       @failed_paths = [] if passed
       @last_failed  = !passed

--- a/lib/guard/rspec/inspector.rb
+++ b/lib/guard/rspec/inspector.rb
@@ -9,6 +9,14 @@ module Guard
         def excluded=(glob)
           @excluded = Dir[glob.to_s]
         end
+        
+        def spec_paths
+          @spec_paths || []
+        end
+        
+        def spec_paths=(path_array)
+          @spec_paths = path_array
+        end
 
         def clean(paths)
           paths.uniq!
@@ -30,11 +38,12 @@ module Guard
         end
 
         def spec_folder?(path)
-          path.match(%r{^spec[^\.]*$})
+          path.match(%r{^(#{spec_paths.join("|")})[^\.]*$})
+          # path.match(%r{^spec[^\.]*$})
         end
 
         def spec_files
-          @spec_files ||= Dir["spec/**/*_spec.rb"]
+          @spec_files ||= spec_paths.collect { |path| Dir[File.join(path, "**", "*_spec.rb")] }.flatten
         end
 
         def clear_spec_files_list_after

--- a/spec/fixtures/other_spec_path/empty_spec.rb
+++ b/spec/fixtures/other_spec_path/empty_spec.rb
@@ -1,0 +1,1 @@
+# Empty file to test spec_paths option

--- a/spec/guard/rspec/inspector_spec.rb
+++ b/spec/guard/rspec/inspector_spec.rb
@@ -4,6 +4,7 @@ describe Guard::RSpec::Inspector do
   describe ".clean" do
     before do
       subject.excluded = nil
+      subject.spec_paths = ["spec/"]
     end
 
     it "removes non-spec files" do
@@ -50,6 +51,16 @@ describe Guard::RSpec::Inspector do
         it 'ignores files recursively' do
           subject.excluded = 'spec/guard/**/*'
           subject.clean(['spec/guard/rspec_spec.rb', 'spec/guard/rspec/runner_spec.rb']).should == []
+        end
+      end
+    end
+    
+    describe 'spec paths' do
+      context 'with an expanded spec path' do
+        before { subject.spec_paths = ["spec", "spec/fixtures/other_spec_path"] }
+                
+        it "should clean paths not specified" do
+          subject.clean(['clean_me/spec/cleaned_spec.rb', 'spec/guard/rspec/runner_spec.rb', 'spec/fixtures/other_spec_path/empty_spec.rb']).should == ['spec/guard/rspec/runner_spec.rb', 'spec/fixtures/other_spec_path/empty_spec.rb']
         end
       end
     end

--- a/spec/guard/rspec_spec.rb
+++ b/spec/guard/rspec_spec.rb
@@ -43,8 +43,14 @@ describe Guard::RSpec do
   end
 
   describe "#run_all" do
-    it "runs all specs in the 'spec/' directory" do
+    it "runs all specs specified by the default 'spec_paths' option" do
       Guard::RSpec::Runner.should_receive(:run).with(["spec/"], anything)
+      subject.run_all
+    end
+    
+    it "should run all specs specified by the 'spec_paths' option" do
+      subject = Guard::RSpec.new([], :spec_paths => ["spec", "spec/fixtures/other_spec_path"])
+      Guard::RSpec::Runner.should_receive(:run).with(["spec", "spec/fixtures/other_spec_path"], anything)
       subject.run_all
     end
 


### PR DESCRIPTION
Add :spec_paths option to RSpec::Guard to add additional paths that contain spec files for Guard to run
