### PR TITLE
put Formatter and Notification(R)Spec into proper namespace

### DIFF
--- a/lib/guard/rspec/formatter.rb
+++ b/lib/guard/rspec/formatter.rb
@@ -1,6 +1,6 @@
 require "#{File.dirname(__FILE__)}/../rspec"
 
-module Formatter
+module Guard::RSpec::Formatter
 
   def guard_message(example_count, failure_count, pending_count, duration)
     message = "#{example_count} examples, #{failure_count} failures"

--- a/lib/guard/rspec/formatters/notification_rspec.rb
+++ b/lib/guard/rspec/formatters/notification_rspec.rb
@@ -1,8 +1,8 @@
 require "#{File.dirname(__FILE__)}/../formatter"
 require "rspec/core/formatters/base_formatter"
 
-class NotificationRSpec < RSpec::Core::Formatters::BaseFormatter
-  include Formatter
+class Guard::RSpec::Formatter::NotificationRSpec < RSpec::Core::Formatters::BaseFormatter
+  include Guard::RSpec::Formatter
 
   def dump_summary(duration, total, failures, pending)
     message = guard_message(total, failures, pending, duration)

--- a/lib/guard/rspec/formatters/notification_spec.rb
+++ b/lib/guard/rspec/formatters/notification_spec.rb
@@ -1,8 +1,8 @@
 require "#{File.dirname(__FILE__)}/../formatter"
 require "spec/runner/formatter/base_formatter"
 
-class NotificationSpec < Spec::Runner::Formatter::BaseFormatter
-  include Formatter
+class Guard::RSpec::Formatter::NotificationSpec < Spec::Runner::Formatter::BaseFormatter
+  include Guard::RSpec::Formatter
 
   def dump_summary(duration, total, failures, pending)
     message = guard_message(total, failures, pending, duration)

--- a/lib/guard/rspec/runner.rb
+++ b/lib/guard/rspec/runner.rb
@@ -27,7 +27,7 @@ module Guard
           cmd_parts << rspec_exec.downcase
           cmd_parts << options[:cli] if options[:cli]
           cmd_parts << "-f progress" if options[:cli].nil? || !options[:cli].split(' ').any? { |w| %w[-f --format].include?(w) }
-          cmd_parts << "-r #{File.dirname(__FILE__)}/formatters/notification_#{rspec_exec.downcase}.rb -f Notification#{rspec_exec}#{rspec_version == 1 ? ":" : " --out "}/dev/null" if options[:notification] != false
+          cmd_parts << "-r #{File.dirname(__FILE__)}/formatters/notification_#{rspec_exec.downcase}.rb -f Guard::RSpec::Formatter::Notification#{rspec_exec}#{rspec_version == 1 ? ":" : " --out "}/dev/null" if options[:notification] != false
           cmd_parts << paths.join(' ')
 
           cmd_parts.join(' ')

--- a/spec/guard/rspec/formatter_spec.rb
+++ b/spec/guard/rspec/formatter_spec.rb
@@ -1,8 +1,8 @@
 require "#{File.dirname(__FILE__)}/../../../lib/guard/rspec/formatter"
 
-describe Formatter do
+describe Guard::RSpec::Formatter do
 
-  subject { Class.new { include Formatter }.new }
+  subject { Class.new { include Guard::RSpec::Formatter }.new }
 
   describe "#guard_message" do
     context 'with a pending example' do

--- a/spec/guard/rspec/runner_spec.rb
+++ b/spec/guard/rspec/runner_spec.rb
@@ -17,7 +17,7 @@ describe Guard::RSpec::Runner do
 
       it "runs with RSpec 2 and without bundler" do
         subject.should_receive(:system).with(
-          "rspec -f progress -r #{@lib_path.join('guard/rspec/formatters/notification_rspec.rb')} -f NotificationRSpec --out /dev/null spec"
+          "rspec -f progress -r #{@lib_path.join('guard/rspec/formatters/notification_rspec.rb')} -f Guard::RSpec::Formatter::NotificationRSpec --out /dev/null spec"
         ).and_return(true)
         subject.run(["spec"])
       end
@@ -37,7 +37,7 @@ describe Guard::RSpec::Runner do
 
       it "runs with RSpec 2 and with Bundler" do
         subject.should_receive(:system).with(
-          "bundle exec rspec -f progress -r #{@lib_path.join('guard/rspec/formatters/notification_rspec.rb')} -f NotificationRSpec --out /dev/null spec"
+          "bundle exec rspec -f progress -r #{@lib_path.join('guard/rspec/formatters/notification_rspec.rb')} -f Guard::RSpec::Formatter::NotificationRSpec --out /dev/null spec"
         ).and_return(true)
         subject.run(["spec"])
       end
@@ -46,7 +46,7 @@ describe Guard::RSpec::Runner do
         describe ":rvm" do
           it "runs with rvm exec" do
             subject.should_receive(:system).with(
-              "rvm 1.8.7,1.9.2 exec bundle exec rspec -f progress -r #{@lib_path.join('guard/rspec/formatters/notification_rspec.rb')} -f NotificationRSpec --out /dev/null spec"
+              "rvm 1.8.7,1.9.2 exec bundle exec rspec -f progress -r #{@lib_path.join('guard/rspec/formatters/notification_rspec.rb')} -f Guard::RSpec::Formatter::NotificationRSpec --out /dev/null spec"
             ).and_return(true)
             subject.run(["spec"], :rvm => ['1.8.7', '1.9.2'])
           end
@@ -55,21 +55,21 @@ describe Guard::RSpec::Runner do
         describe ":cli" do
           it "runs with CLI options passed to RSpec" do
             subject.should_receive(:system).with(
-            "bundle exec rspec --color --drb --fail-fast -f progress -r #{@lib_path.join('guard/rspec/formatters/notification_rspec.rb')} -f NotificationRSpec --out /dev/null spec"
+            "bundle exec rspec --color --drb --fail-fast -f progress -r #{@lib_path.join('guard/rspec/formatters/notification_rspec.rb')} -f Guard::RSpec::Formatter::NotificationRSpec --out /dev/null spec"
             ).and_return(true)
             subject.run(["spec"], :cli => "--color --drb --fail-fast")
           end
 
           it "sets progress formatter by default if no formatter is passed in CLI options to RSpec" do
             subject.should_receive(:system).with(
-            "bundle exec rspec -f progress -r #{@lib_path.join('guard/rspec/formatters/notification_rspec.rb')} -f NotificationRSpec --out /dev/null spec"
+            "bundle exec rspec -f progress -r #{@lib_path.join('guard/rspec/formatters/notification_rspec.rb')} -f Guard::RSpec::Formatter::NotificationRSpec --out /dev/null spec"
             ).and_return(true)
             subject.run(["spec"])
           end
 
           it "respects formatter passed in CLI options to RSpec" do
             subject.should_receive(:system).with(
-            "bundle exec rspec -f doc -r #{@lib_path.join('guard/rspec/formatters/notification_rspec.rb')} -f NotificationRSpec --out /dev/null spec"
+            "bundle exec rspec -f doc -r #{@lib_path.join('guard/rspec/formatters/notification_rspec.rb')} -f Guard::RSpec::Formatter::NotificationRSpec --out /dev/null spec"
             ).and_return(true)
             subject.run(["spec"], :cli => "-f doc")
           end
@@ -78,7 +78,7 @@ describe Guard::RSpec::Runner do
         describe ":bundler" do
           it "runs without Bundler with bundler option to false" do
             subject.should_receive(:system).with(
-              "rspec -f progress -r #{@lib_path.join('guard/rspec/formatters/notification_rspec.rb')} -f NotificationRSpec --out /dev/null spec"
+              "rspec -f progress -r #{@lib_path.join('guard/rspec/formatters/notification_rspec.rb')} -f Guard::RSpec::Formatter::NotificationRSpec --out /dev/null spec"
             ).and_return(true)
             subject.run(["spec"], :bundler => false)
           end
@@ -115,7 +115,7 @@ describe Guard::RSpec::Runner do
 
       it "runs with RSpec 1 and with bundler" do
         subject.should_receive(:system).with(
-          "bundle exec spec -f progress -r #{@lib_path.join('guard/rspec/formatters/notification_spec.rb')} -f NotificationSpec:/dev/null spec"
+          "bundle exec spec -f progress -r #{@lib_path.join('guard/rspec/formatters/notification_spec.rb')} -f Guard::RSpec::Formatter::NotificationSpec:/dev/null spec"
         ).and_return(true)
         subject.run(["spec"])
       end


### PR DESCRIPTION
this resolves a conflict with puppet, which uses 'class Formatter'
