### PR TITLE
strip trailing '/' from default spec_paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ guard 'rspec', :cli => "--color --format nested --fail-fast --drb" do
 end
 ```
 
-By default, Guard::RSpec will only look for spec files within `spec/` in your project root. You can configure Guard::RSpec to look in additional paths by using the `:spec_paths` option:
+By default, Guard::RSpec will only look for spec files within `spec` in your project root. You can configure Guard::RSpec to look in additional paths by using the `:spec_paths` option:
 
 ``` ruby
 guard 'rspec', :spec_paths => ["spec", "vendor/engines/reset/spec"] do
@@ -110,7 +110,7 @@ Former `:color`, `:drb`, `:fail_fast` and `:formatter` options are thus deprecat
 :all_on_start => false       # don't run all the specs at startup, default: true
 :keep_failed => false        # don't keep failed specs until they pass, default: true
 :run_all => { :cli => "-p" } # override any option when running all specs
-:spec_paths => ["spec/"]     # specify an array of paths that contain spec files
+:spec_paths => ["spec"]      # specify an array of paths that contain spec files
 ```
 
 Notification

--- a/lib/guard/rspec.rb
+++ b/lib/guard/rspec.rb
@@ -12,7 +12,7 @@ module Guard
         :all_after_pass => true,
         :all_on_start   => true,
         :keep_failed    => true,
-        :spec_paths     => ["spec/"]
+        :spec_paths     => ["spec"]
       }.update(options)
       @last_failed  = false
       @failed_paths = []

--- a/lib/guard/rspec/templates/Guardfile
+++ b/lib/guard/rspec/templates/Guardfile
@@ -1,15 +1,15 @@
 guard 'rspec', :version => 2 do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
-  watch('spec/spec_helper.rb')  { "spec/" }
+  watch('spec/spec_helper.rb')  { "spec" }
 
   # Rails example
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^app/(.+)\.rb$})                           { |m| "spec/#{m[1]}_spec.rb" }
   watch(%r{^lib/(.+)\.rb$})                           { |m| "spec/lib/#{m[1]}_spec.rb" }
   watch(%r{^app/controllers/(.+)_(controller)\.rb$})  { |m| ["spec/routing/#{m[1]}_routing_spec.rb", "spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb", "spec/acceptance/#{m[1]}_spec.rb"] }
-  watch(%r{^spec/support/(.+)\.rb$})                  { "spec/" }
-  watch('spec/spec_helper.rb')                        { "spec/" }
+  watch(%r{^spec/support/(.+)\.rb$})                  { "spec" }
+  watch('spec/spec_helper.rb')                        { "spec" }
   watch('config/routes.rb')                           { "spec/routing" }
   watch('app/controllers/application_controller.rb')  { "spec/controllers" }
   # Capybara request specs

--- a/spec/guard/rspec/inspector_spec.rb
+++ b/spec/guard/rspec/inspector_spec.rb
@@ -4,7 +4,7 @@ describe Guard::RSpec::Inspector do
   describe ".clean" do
     before do
       subject.excluded = nil
-      subject.spec_paths = ["spec/"]
+      subject.spec_paths = ["spec"]
     end
 
     it "accept a string as spec_paths" do

--- a/spec/guard/rspec_spec.rb
+++ b/spec/guard/rspec_spec.rb
@@ -44,10 +44,10 @@ describe Guard::RSpec do
 
   describe "#run_all" do
     it "runs all specs specified by the default 'spec_paths' option" do
-      Guard::RSpec::Runner.should_receive(:run).with(["spec/"], anything)
+      Guard::RSpec::Runner.should_receive(:run).with(["spec"], anything)
       subject.run_all
     end
-    
+
     it "should run all specs specified by the 'spec_paths' option" do
       subject = Guard::RSpec.new([], :spec_paths => ["spec", "spec/fixtures/other_spec_path"])
       Guard::RSpec::Runner.should_receive(:run).with(["spec", "spec/fixtures/other_spec_path"], anything)


### PR DESCRIPTION
guard-rspec silently ignores watchers like `watch('spec/spec_helper.rb') { "spec" }` (ironically taken from guard-rspec's Guardfile) without trailing '/'. Debugging this behaviour can be quite frustrating, as it is unexpected if you are used to autotest or guard-cucumber. The change is backwards compatible, so existing Guardfiles won't have to be changed.
