### PR TITLE
Include gherkin .feature files

### DIFF
--- a/lib/guard/rspec/inspector.rb
+++ b/lib/guard/rspec/inspector.rb
@@ -30,11 +30,15 @@ module Guard
       private
 
         def should_run_spec_file?(path)
-          (spec_file?(path) || spec_folder?(path)) && !excluded.include?(path)
+          (spec_file?(path) || feature_file?(path) || spec_folder?(path)) && !excluded.include?(path)
         end
 
         def spec_file?(path)
           spec_files.include?(path)
+        end
+
+        def feature_file?(path)
+          feature_files.include?(path)
         end
 
         def spec_folder?(path)
@@ -44,6 +48,10 @@ module Guard
 
         def spec_files
           @spec_files ||= spec_paths.collect { |path| Dir[File.join(path, "**", "*_spec.rb")] }.flatten
+        end
+
+        def feature_files
+          @feature_files ||= spec_paths.collect { |path| Dir[File.join(path, "**", "*.feature")] }.flatten
         end
 
         def clear_spec_files_list_after


### PR DESCRIPTION
I was playing with [Turnip](/jnicklas/turnip), which allows the running of Gherkin .feature files through rspec. As it allows rspec to treat any .feature file just as a _spec.rb, I expected guard-rspec to pick them up automatically.

As it turns out, there's a very specific filter in the guard-rspec inspector to include only `**/*_spec.rb` files. I've made a simple modification to include `**/*.feature` files in the list of files that can be run.

I'm not sure if this is an appropriate implementation for all users of the library or if this should be externalized to another module. It worked for me and I thought I'd see if you're interested in pulling it into master.

Thanks!

Jason
