### PR TITLE
Don't notify of a failure when specs pass

### DIFF
--- a/lib/guard/rspec/runner.rb
+++ b/lib/guard/rspec/runner.rb
@@ -10,7 +10,7 @@ module Guard
           UI.info(message, :reset => true)
           system(rspec_command(paths, options))
 
-          if options[:notification] != false && failure_exit_code_supported?(options) && $? && $?.exitstatus == failure_exit_code
+          if options[:notification] != false && failure_exit_code_supported?(options) && $? && !$?.success? && $?.exitstatus != failure_exit_code
             Notifier.notify("Failed", :title => "RSpec results", :image => :failed, :priority => 2)
           end
         end

--- a/spec/guard/rspec/runner_spec.rb
+++ b/spec/guard/rspec/runner_spec.rb
@@ -38,14 +38,21 @@ describe Guard::RSpec::Runner do
 
       it "notifies when RSpec fails to execute" do
         subject.should_receive(:system).and_return(nil)
-        system("`exit 2`") # prime the $? variable
+        system("`exit 1`") # prime the $? variable
         Guard::Notifier.should_receive(:notify).with("Failed", :title => "RSpec results", :image => :failed, :priority => 2)
         subject.run(["spec"])
       end
 
       it "does not notify that RSpec failed when the specs failed" do
         subject.should_receive(:system).and_return(nil)
-        system("`exit -1`") # prime the $? variable
+        system("`exit 2`") # prime the $? variable
+        Guard::Notifier.should_not_receive(:notify).with("Failed", :title => "RSpec results", :image => :failed, :priority => 2)
+        subject.run(["spec"])
+      end
+
+      it "does not notify that RSpec failed when the specs pass" do
+        subject.should_receive(:system)
+        system("`exit 0`") # prime the $? variable
         Guard::Notifier.should_not_receive(:notify).with("Failed", :title => "RSpec results", :image => :failed, :priority => 2)
         subject.run(["spec"])
       end


### PR DESCRIPTION
Fixes #65

When executing `rspec --failure-exit-code 2` that tells RSpec to return 2 when the specs fail to pass, which is the case handled by the RSpec formatter. When RSpec succeeds, obviously the exit code is 0 and that is also a case handled by the formatter -- but one the error handling code wasn't accounting for. When RSpec fails to run because of an exception while loading the code, then Ruby returns an exit code of 1.

The error handling code needs to notify if the error code !=0 and != failure_exit_code.
