### PR TITLE
Explicitly require guard/notifier because there are some cases where the...

### DIFF
--- a/lib/guard/rspec/formatter.rb
+++ b/lib/guard/rspec/formatter.rb
@@ -1,4 +1,5 @@
 require "#{File.dirname(__FILE__)}/../rspec"
+require 'guard/notifier'
 
 module Guard::RSpec::Formatter
 


### PR DESCRIPTION
... autoloading doesn't work.
