### PR TITLE
Fix for default format option

### DIFF
--- a/lib/guard/rspec/runner.rb
+++ b/lib/guard/rspec/runner.rb
@@ -30,7 +30,7 @@ module Guard
         cmd_parts << "bundle exec" if (bundler? && options[:binstubs] == true && options[:bundler] != false) || (bundler? && options[:bundler] != false)
         cmd_parts << rspec_exec(options)
         cmd_parts << options[:cli] if options[:cli]
-        cmd_parts << "-f progress" if options[:cli].nil? || !options[:cli].split(' ').any? { |w| %w[-f --format].grep(/^#{w}/) }
+        cmd_parts << "-f progress" if options[:cli].nil? || !options[:cli].split(/[\s=]/).any? { |w| %w[-f --format].include?(w) }
         cmd_parts << "-r #{File.dirname(__FILE__)}/formatters/notification_#{rspec_class.downcase}.rb -f Guard::RSpec::Formatter::Notification#{rspec_class}#{rspec_version == 1 ? ":" : " --out "}/dev/null" if options[:notification] != false
         cmd_parts << "--failure-exit-code #{failure_exit_code}" if failure_exit_code_supported?(options)
         cmd_parts << paths.join(' ')


### PR DESCRIPTION
"-f progress" should be added to cmd_parts unless there is a -f or --format=xyz included in the cli options.

However the recent fix 53cc1fa0f81e6cf436d3d75cca5068272841e153 for --format actually stops "-f progress" from being added unless are no cli options as grep always returns at least an empty array (thus true).
