### PR TITLE
handle specs for lib/*.rb files when no spec/lib

### DIFF
--- a/lib/guard/rspec/templates/Guardfile
+++ b/lib/guard/rspec/templates/Guardfile
@@ -1,6 +1,6 @@
 guard 'rspec', :version => 2 do
   watch(%r{^spec/.+_spec\.rb$})
-  watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
+  watch(%r{^lib/(.+)\.rb$})     { |m| "spec/#{Dir.exist?('spec/lib') ? 'lib/' : '' }#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb')  { "spec" }
 
   # Rails example


### PR DESCRIPTION
The mapping lib/foo.rb -> spec/lib/foo.rb is common for rails apps.

Many gems have lib/foo.rb -> spec/foo.rb instead, and some tools expect this
(vim-rake + :A , for example).

Even the guard-rspec specs :)

SOLUTION: handle both (spec/lib/foo.rb, spec/foo.rb)

I didn't provide tests because:
- there are no tests for the Guardfile template
- the tests don't run on my setup (recent gems)
- don't have time at this moment

Anyway, thanks for the gem.
