### PR TITLE
Support spec and feature files in the top level of the project's spec/features dir

### DIFF
--- a/lib/guard/rspec/inspector.rb
+++ b/lib/guard/rspec/inspector.rb
@@ -51,11 +51,11 @@ module Guard
       end
 
       def spec_files
-        @spec_files ||= spec_paths.collect { |path| Dir[File.join(path, "**/*/**", "*_spec.rb")] }.flatten
+        @spec_files ||= spec_paths.collect { |path| Dir[File.join(path, "**", "*_spec.rb")] }.flatten
       end
 
       def feature_files
-        @feature_files ||= spec_paths.collect { |path| Dir[File.join(path, "**/*/**", "*.feature")] }.flatten
+        @feature_files ||= spec_paths.collect { |path| Dir[File.join(path, "**", "*.feature")] }.flatten
       end
 
       def clear_spec_files_list_after


### PR DESCRIPTION
Unsure if there's some rationale behind this; but it's confusing to have a `spec/foo_spec.rb` and have guard-rspec refuse to run it by default
