### PR TITLE
Fix .rspec formatter regex

### DIFF
--- a/lib/guard/rspec/runner.rb
+++ b/lib/guard/rspec/runner.rb
@@ -211,7 +211,7 @@ module Guard
       end
 
       def formatter_regex
-        @formatter_regex ||= /(?:^|\s)(?:-f\s*|--format(?:=|\s+))(\w+)/
+        @formatter_regex ||= /(?:^|\s)(?:-f\s*|--format(?:=|\s+))([\w:]+)/
       end
 
     end

--- a/spec/guard/rspec/runner_spec.rb
+++ b/spec/guard/rspec/runner_spec.rb
@@ -390,11 +390,11 @@ describe Guard::RSpec::Runner do
 
       context 'and includes a --format option' do
         before do
-          File.stub(:read).and_return("--colour\n--format documentation")
+          File.stub(:read).and_return("--colour\n--format RSpec::Instafail")
         end
 
         it 'returns the formatter from .rspec file' do
-          subject.parsed_or_default_formatter.should eq '-f documentation'
+          subject.parsed_or_default_formatter.should eq '-f RSpec::Instafail'
         end
       end
 


### PR DESCRIPTION
The regex that pulls the formatter option out of the .rspec file previously didn't match strings such as "RSpec::Instafail", this pull request fixes that.

Thanks!
