### PR TITLE
Enabled color coding by default

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,4 +1,4 @@
-guard 'rspec', :version => 2 do
+guard 'rspec', :version => 2, :cli => "--color" do
   watch(%r{^spec/.+_spec\.rb})
   watch(%r{^lib/(.+)\.rb})     { |m| "spec/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb') { "spec" }

--- a/lib/guard/rspec/templates/Guardfile
+++ b/lib/guard/rspec/templates/Guardfile
@@ -1,4 +1,4 @@
-guard 'rspec', :version => 2 do
+guard 'rspec', :version => 2, :cli => "--color" do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb')  { "spec" }

--- a/spec/fixtures/rspec2/Guardfile
+++ b/spec/fixtures/rspec2/Guardfile
@@ -1,4 +1,4 @@
-guard 'rspec', :version => 2 do
+guard 'rspec', :version => 2, :cli => "--color" do
   watch(%r{^spec/.+_spec\.rb})
   watch(%r{^lib/(.+)\.rb})     { |m| "spec/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb') { "spec" }


### PR DESCRIPTION
Finding a way to enable color coding in some configurations can be
difficult. This enables it by default.
