### PR TITLE
:binstubs now accept a String as the directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ Former `:color`, `:drb`, `:fail_fast` and `:formatter` options are deprecated an
 :turnip => true              # enable turnip support; default: false
 ```
 
+You can also use a custom binstubs directory using `:binstubs => 'some-dir'`.
+
 ### DRb mode
 
 When you specify `--drb` within `:cli`, guard-rspec will circumvent the `rspec` command line tool by

--- a/lib/guard/rspec/runner.rb
+++ b/lib/guard/rspec/runner.rb
@@ -40,7 +40,7 @@ module Guard
       def rspec_executable
         @rspec_executable ||= begin
           exec = rspec_class.downcase
-          binstubs? ? "bin/#{exec}" : exec
+          binstubs? ? "#{binstubs}/#{exec}" : exec
         end
       end
 
@@ -188,6 +188,14 @@ module Guard
           @binstubs = bundler? && @options[:binstubs]
         else
           @binstubs
+        end
+      end
+
+      def binstubs
+        if @options[:binstubs] == true
+          "bin"
+        else
+          @options[:binstubs]
         end
       end
 

--- a/spec/guard/rspec/runner_spec.rb
+++ b/spec/guard/rspec/runner_spec.rb
@@ -320,6 +320,19 @@ describe Guard::RSpec::Runner do
               subject.run(['spec'])
             end
           end
+
+          context ':bundler => true, :binstubs => "dir"' do
+            subject { described_class.new(:bundler => true, :binstubs => 'dir') }
+
+            it 'runs with Bundler and binstubs in custom directory' do
+              subject.should_receive(:system).with(
+                "bundle exec dir/rspec -f progress -r #{@lib_path.join('guard/rspec/formatters/notification_rspec.rb')} " <<
+                '-f Guard::RSpec::Formatter::NotificationRSpec --out /dev/null --failure-exit-code 2 spec'
+              ).and_return(true)
+
+              subject.run(['spec'])
+            end
+          end
         end
 
         describe ':notification' do


### PR DESCRIPTION
Bundler can store binstubs in other directories instead of the default `bin/`.
