### PR TITLE
Binstubs without bundle exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ Former `:color`, `:drb`, `:fail_fast` and `:formatter` options are deprecated an
 ``` ruby
 :version => 1                # force use RSpec version 1, default: 2
 :cli => "-c -f doc"          # pass arbitrary RSpec CLI arguments, default: "-f progress"
-:bundler => false            # don't use "bundle exec" to run the RSpec command, default: true
-:binstubs => true            # use "bin/rspec" to run the RSpec command (implies :bundler => true), default: false
+:bundler => false            # use "bundle exec" to run the RSpec command, default: true
+:binstubs => true            # use "bin/rspec" to run the RSpec command (takes precedence over :bundle), default: false
 :rvm => ['1.8.7', '1.9.2']   # directly run your specs on multiple Rubies, default: nil
 :notification => false       # display Growl (or Libnotify) notification after the specs are done running, default: true
 :all_after_pass => false     # run all specs after changed specs pass, default: true

--- a/lib/guard/rspec/runner.rb
+++ b/lib/guard/rspec/runner.rb
@@ -47,7 +47,7 @@ module Guard
       def failure_exit_code_supported?
         @failure_exit_code_supported ||= begin
           cmd_parts = []
-          cmd_parts << "bundle exec" if bundler?
+          cmd_parts << "bundle exec" if bundle_exec?
           cmd_parts << rspec_executable
           cmd_parts << "--help"
           `#{cmd_parts.join(' ')}`.include? "--failure-exit-code"
@@ -95,7 +95,7 @@ module Guard
       def rspec_command(paths, options)
         cmd_parts = []
         cmd_parts << "rvm #{@options[:rvm].join(',')} exec" if @options[:rvm].respond_to?(:join)
-        cmd_parts << "bundle exec" if bundler?
+        cmd_parts << "bundle exec" if bundle_exec?
         cmd_parts << rspec_executable
         cmd_parts << rspec_arguments(paths, options)
         cmd_parts.compact.join(' ')
@@ -185,7 +185,7 @@ module Guard
 
       def binstubs?
         if @binstubs.nil?
-          @binstubs = bundler? && @options[:binstubs]
+          @binstubs = !!@options[:binstubs]
         else
           @binstubs
         end
@@ -197,6 +197,10 @@ module Guard
         else
           @options[:binstubs]
         end
+      end
+
+      def bundle_exec?
+        bundler? && !binstubs?
       end
 
       def determine_rspec_version

--- a/spec/guard/rspec/runner_spec.rb
+++ b/spec/guard/rspec/runner_spec.rb
@@ -298,9 +298,9 @@ describe Guard::RSpec::Runner do
           context ':bundler => false, :binstubs => true' do
             subject { described_class.new(:bundler => false, :binstubs => true) }
 
-            it 'runs without Bundler and binstubs' do
+            it 'runs without Bundler and with binstubs' do
               subject.should_receive(:system).with(
-                "rspec -f progress -r #{@lib_path.join('guard/rspec/formatters/notification_rspec.rb')} " <<
+                "bin/rspec -f progress -r #{@lib_path.join('guard/rspec/formatters/notification_rspec.rb')} " <<
                 '-f Guard::RSpec::Formatter::NotificationRSpec --out /dev/null --failure-exit-code 2 spec'
               ).and_return(true)
 
@@ -311,9 +311,9 @@ describe Guard::RSpec::Runner do
           context ':bundler => true, :binstubs => true' do
             subject { described_class.new(:bundler => true, :binstubs => true) }
 
-            it 'runs with Bundler and binstubs' do
+            it 'runs without Bundler and binstubs' do
               subject.should_receive(:system).with(
-                "bundle exec bin/rspec -f progress -r #{@lib_path.join('guard/rspec/formatters/notification_rspec.rb')} " <<
+                "bin/rspec -f progress -r #{@lib_path.join('guard/rspec/formatters/notification_rspec.rb')} " <<
                 '-f Guard::RSpec::Formatter::NotificationRSpec --out /dev/null --failure-exit-code 2 spec'
               ).and_return(true)
 
@@ -324,9 +324,9 @@ describe Guard::RSpec::Runner do
           context ':bundler => true, :binstubs => "dir"' do
             subject { described_class.new(:bundler => true, :binstubs => 'dir') }
 
-            it 'runs with Bundler and binstubs in custom directory' do
+            it 'runs without Bundler and binstubs in custom directory' do
               subject.should_receive(:system).with(
-                "bundle exec dir/rspec -f progress -r #{@lib_path.join('guard/rspec/formatters/notification_rspec.rb')} " <<
+                "dir/rspec -f progress -r #{@lib_path.join('guard/rspec/formatters/notification_rspec.rb')} " <<
                 '-f Guard::RSpec::Formatter::NotificationRSpec --out /dev/null --failure-exit-code 2 spec'
               ).and_return(true)
 


### PR DESCRIPTION
This is an increment to my PR https://github.com/guard/guard-rspec/pull/118

I've noticed that we were using `bundle exe bin/rspec` when using binstubs.

According to the bundler documentation (http://gembundler.com/man/bundle-exec.1.html), `bin/rspec` is identical to `bundle exec rspec`. The only difference is that binstubs are faster, because we are not generating a `bundle exec` process just to run rspec.

This somewhat breaks the affirmation int the README that says that `:binstubs` implies `:bundler`.

wdyt?
