### PR TITLE
Ensuring 1.8.7 compatability

### DIFF
--- a/lib/guard/rspec/formatter.rb
+++ b/lib/guard/rspec/formatter.rb
@@ -5,7 +5,7 @@ require "rspec/core/formatters/base_formatter"
 class Guard::RSpec::Formatter < RSpec::Core::Formatters::BaseFormatter
 
   def dump_summary(duration, total, failures, pending)
-    failed_specs = examples.keep_if{|e| e.execution_result[:status] == "failed"}.map{|s| s.metadata[:location]}
+    failed_specs = examples.delete_if{|e| e.execution_result[:status] != "failed"}.map{|s| s.metadata[:location]}
 
     # if this fails don't kill everything
     begin

--- a/spec/guard/rspec/runner_spec.rb
+++ b/spec/guard/rspec/runner_spec.rb
@@ -124,7 +124,7 @@ describe Guard::RSpec::Runner do
 
           it 'honors --drb-port' do
             service.should_receive(:run) { 0 }
-            subject.run(['spec'], cli: '--drb --drb-port 2222')
+            subject.run(['spec'], :cli => '--drb --drb-port 2222')
             service.port.should == 2222
           end
         end


### PR DESCRIPTION
Very minor tweaks - replacing keep_if with delete_if and hash syntax in one spec.
Seems like a point release shouldn't require an update in Ruby.
Still one failing test but believe this to be unrelated.
