### PR TITLE
Remove trailing newlines from Guardfile template.

### DIFF
--- a/lib/guard/rspec/templates/Guardfile
+++ b/lib/guard/rspec/templates/Guardfile
@@ -18,4 +18,3 @@ guard 'rspec' do
   watch(%r{^spec/acceptance/(.+)\.feature$})
   watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$})   { |m| Dir[File.join("**/#{m[1]}.feature")][0] || 'spec/acceptance' }
 end
-


### PR DESCRIPTION
Minor change, but it annoys me every single time.
