### PR TITLE
Add support to ParallelTests #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Gemfile.lock
 *.rbc
 tmp/*
 *.swp
+.rvmrc
 
 ## MAC OS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ guard 'rspec', :spring => true do
   # ...
 end
 ```
+[ParallelTests](https://github.com/grosser/parallel_tests) is supported, but you must enable it:
+``` ruby
+guard 'rspec', :parallel => true, :parallel_cli => '-n 2' do
+  # ...
+end
+```
 
 Former `:color`, `:drb`, `:fail_fast` and `:formatter` options are deprecated and have no effect anymore.
 
@@ -127,6 +133,8 @@ Former `:color`, `:drb`, `:fail_fast` and `:formatter` options are deprecated an
 :turnip => true              # enable turnip support; default: false
 :zeus => true                # enable zeus support; default: false
 :focus_on_failed => false    # focus on the first 10 failed specs first, rerun till they pass
+:parallel => true            # run all specs in parallel using [ParallelTests](https://github.com/grosser/parallel_tests) gem, default: false
+:parallel_cli => "-n 2"      # pass arbitrary Parallel Tests arguments, default: ""
 ```
 
 You can also use a custom binstubs directory using `:binstubs => 'some-dir'`.

--- a/spec/guard/rspec/runner_spec.rb
+++ b/spec/guard/rspec/runner_spec.rb
@@ -52,13 +52,27 @@ describe Guard::RSpec::Runner do
         Dir.stub(:pwd).and_return(@fixture_path.join('empty'))
       end
 
-      it 'runs with RSpec 2 and without bundler' do
-        subject.should_receive(:system).with(
-          "rspec -f progress -r #{@lib_path.join('guard/rspec/formatter.rb')} " <<
-          '-f Guard::RSpec::Formatter --failure-exit-code 2 spec'
-        ).and_return(true)
+      context ':parallel => false' do
+        it 'runs with RSpec 2 and without bundler' do
+          subject.should_receive(:system).with(
+            "rspec -f progress -r #{@lib_path.join('guard/rspec/formatter.rb')} " <<
+            '-f Guard::RSpec::Formatter --failure-exit-code 2 spec'
+          ).and_return(true)
 
-        subject.run(['spec'])
+          subject.run(['spec'])
+        end
+      end
+      context ':parallel => true' do
+        subject { described_class.new(:parallel => true) }
+
+        it 'runs with Parallel Tests and without bundler' do
+          subject.should_receive(:system).with(
+            "parallel_rspec -f progress -r #{@lib_path.join('guard/rspec/formatter.rb')} " <<
+            "-f Guard::RSpec::Formatter --failure-exit-code 2 spec"
+          ).and_return(true)
+
+          subject.run(['spec'])
+        end
       end
     end
 
@@ -67,13 +81,27 @@ describe Guard::RSpec::Runner do
         Dir.stub(:pwd).and_return(@fixture_path.join('rspec2'))
       end
 
-      it 'runs with RSpec 2 and with Bundler' do
-        subject.should_receive(:system).with(
-          "bundle exec rspec -f progress -r #{@lib_path.join('guard/rspec/formatter.rb')} " <<
-          '-f Guard::RSpec::Formatter --failure-exit-code 2 spec'
-        ).and_return(true)
+      context ':parallel => false' do
+        it 'runs with RSpec 2 and with Bundler' do
+          subject.should_receive(:system).with(
+            "bundle exec rspec -f progress -r #{@lib_path.join('guard/rspec/formatter.rb')} " <<
+            '-f Guard::RSpec::Formatter --failure-exit-code 2 spec'
+          ).and_return(true)
 
-        subject.run(['spec'])
+          subject.run(['spec'])
+        end
+      end
+      context ':parallel => true' do
+        subject { described_class.new(:parallel => true) }
+
+        it 'runs with Parallel Tests and without bundler' do
+          subject.should_receive(:system).with(
+            "bundle exec parallel_rspec -f progress -r #{@lib_path.join('guard/rspec/formatter.rb')} " <<
+            "-f Guard::RSpec::Formatter --failure-exit-code 2 spec"
+          ).and_return(true)
+
+          subject.run(['spec'])
+        end
       end
 
       describe 'notification' do
@@ -224,6 +252,19 @@ describe Guard::RSpec::Runner do
                 )
                 subject.run(['spec'])
               end
+            end
+          end
+
+          context ':zeus => true, :parallel => true' do
+            subject { described_class.new(:zeus => true, :parallel => true) }
+
+            it 'runs with Parallel Tests and without zeus' do
+              subject.should_receive(:system).with(
+                "bundle exec parallel_rspec -f progress -r #{@lib_path.join('guard/rspec/formatter.rb')} " <<
+                "-f Guard::RSpec::Formatter --failure-exit-code 2 spec"
+              ).and_return(true)
+
+              subject.run(['spec'])
             end
           end
         end
@@ -431,6 +472,22 @@ describe Guard::RSpec::Runner do
                 "export RAILS_ENV=blue; bundle exec rspec -f progress -r #{@lib_path.join('guard/rspec/formatter.rb')} " <<
                 '-f Guard::RSpec::Formatter --failure-exit-code 2 spec'
                 ).and_return(true)
+
+              subject.run(['spec'])
+            end
+          end
+        end
+
+        describe ':parallel' do
+          context ":parallel_cli => '-n 2', :cli => '--color --drb --fail-fast'" do
+            subject { described_class.new(:parallel => true, :parallel_cli => '-n 2', :cli => '--color --drb --fail-fast') }
+
+            it 'runs with CLI options passed to RSpec' do
+              subject.should_receive(:system).with(
+                "bundle exec parallel_rspec -n 2 -f progress " <<
+                "-r #{@lib_path.join('guard/rspec/formatter.rb')} " <<
+                "-f Guard::RSpec::Formatter --failure-exit-code 2 spec"
+              ).and_return(true)
 
               subject.run(['spec'])
             end


### PR DESCRIPTION
Hi,

since i needed the feature from #150, i've recreaded the patch from @rafaelp on top of your current master.
It should be mergeable now.
I hope to not annoy @rafaelp with that. I/we know that you created the patch in the first place (Thank you again for that :yum: )

Here is his original message:

> I've added a option to run specs using parallel_rspec instead of rspec command.
> 
> There are more people looking for it, as we can see at http://stackoverflow.com/questions/13470493/is-it-possible-use-guard-in-combination-with-parallel-tests
