### PR TITLE
send rspec options to parallel_tests using -o

### DIFF
--- a/lib/guard/rspec/runner.rb
+++ b/lib/guard/rspec/runner.rb
@@ -96,13 +96,7 @@ module Guard
       def parallel_rspec_arguments(paths, options)
         arg_parts = []
         arg_parts << options[:parallel_cli]
-        if @options[:notification]
-          arg_parts << parsed_or_default_formatter unless options[:cli] =~ formatter_regex
-          arg_parts << "-r #{File.dirname(__FILE__)}/formatter.rb"
-          arg_parts << "-f Guard::RSpec::Formatter"
-        end
-        arg_parts << "--failure-exit-code #{FAILURE_EXIT_CODE}" if failure_exit_code_supported?
-        #arg_parts << "-r turnip/rspec" if @options[:turnip]
+        arg_parts << "-o '#{rspec_arguments([], options).strip}'"
         arg_parts << paths.join(' ')
 
         arg_parts.compact.join(' ')

--- a/spec/guard/rspec/runner_spec.rb
+++ b/spec/guard/rspec/runner_spec.rb
@@ -67,8 +67,8 @@ describe Guard::RSpec::Runner do
 
         it 'runs with Parallel Tests and without bundler' do
           subject.should_receive(:system).with(
-            "parallel_rspec -f progress -r #{@lib_path.join('guard/rspec/formatter.rb')} " <<
-            "-f Guard::RSpec::Formatter --failure-exit-code 2 spec"
+            "parallel_rspec -o '-f progress -r #{@lib_path.join('guard/rspec/formatter.rb')} " <<
+            "-f Guard::RSpec::Formatter --failure-exit-code 2' spec"
           ).and_return(true)
 
           subject.run(['spec'])
@@ -96,8 +96,8 @@ describe Guard::RSpec::Runner do
 
         it 'runs with Parallel Tests and without bundler' do
           subject.should_receive(:system).with(
-            "bundle exec parallel_rspec -f progress -r #{@lib_path.join('guard/rspec/formatter.rb')} " <<
-            "-f Guard::RSpec::Formatter --failure-exit-code 2 spec"
+            "bundle exec parallel_rspec -o '-f progress -r #{@lib_path.join('guard/rspec/formatter.rb')} " <<
+            "-f Guard::RSpec::Formatter --failure-exit-code 2' spec"
           ).and_return(true)
 
           subject.run(['spec'])
@@ -260,8 +260,8 @@ describe Guard::RSpec::Runner do
 
             it 'runs with Parallel Tests and without zeus' do
               subject.should_receive(:system).with(
-                "bundle exec parallel_rspec -f progress -r #{@lib_path.join('guard/rspec/formatter.rb')} " <<
-                "-f Guard::RSpec::Formatter --failure-exit-code 2 spec"
+                "bundle exec parallel_rspec -o '-f progress -r #{@lib_path.join('guard/rspec/formatter.rb')} " <<
+                "-f Guard::RSpec::Formatter --failure-exit-code 2' spec"
               ).and_return(true)
 
               subject.run(['spec'])
@@ -484,9 +484,9 @@ describe Guard::RSpec::Runner do
 
             it 'runs with CLI options passed to RSpec' do
               subject.should_receive(:system).with(
-                "bundle exec parallel_rspec -n 2 -f progress " <<
+                "bundle exec parallel_rspec -n 2 -o '--color --drb --fail-fast -f progress " <<
                 "-r #{@lib_path.join('guard/rspec/formatter.rb')} " <<
-                "-f Guard::RSpec::Formatter --failure-exit-code 2 spec"
+                "-f Guard::RSpec::Formatter --failure-exit-code 2' spec"
               ).and_return(true)
 
               subject.run(['spec'])


### PR DESCRIPTION
Running guard-rspec with notifications and parallel_tests, I received the following error:

```
15:59:23 - INFO - Guard uses Growl to send notifications.
15:59:28 - INFO - Guard::RSpec is running
15:59:28 - INFO - Running all specs
.../gems/parallel_tests-0.10.0/lib/parallel_tests/cli.rb:65:in `parse_options!': invalid option: -r (OptionParser::InvalidOption)
    from .../gems/parallel_tests-0.10.0/lib/parallel_tests/cli.rb:6:in `run'
    from .../gems/parallel_tests-0.10.0/bin/parallel_rspec:5:in `<top (required)>'
    from .../bin/parallel_rspec:19:in `load'
    from .../bin/parallel_rspec:19:in `<main>'
    from .../bin/ruby_noexec_wrapper:14:in `eval'
    from .../bin/ruby_noexec_wrapper:14:in `<main>'
```

Tracked it down to the options passed to parallel_tests. Need to wrap the rspec options with -o
