### PR TITLE
Don't exclude Zeus and Parallel tests

### DIFF
--- a/lib/guard/rspec/runner.rb
+++ b/lib/guard/rspec/runner.rb
@@ -26,6 +26,10 @@ module Guard
           UI.warning "The SPEC_OPTS environment variable is present. This can conflict with guard-rspec, particularly notifications."
         end
 
+        if @options[:bundler] && @options[:zeus] && !@options[:binstubs]
+          UI.warning "Running Zeus within bundler is waste of time. It is recommended to set bundler option to false, when using zeus."
+        end
+
         deprecations_warnings
       end
 


### PR DESCRIPTION
I am working on gem which brings those tools working together:

https://github.com/sevos/zeus-parallel_tests

This change would allow me to avoid monkey patching :)
