### PR TITLE
For DRb service, use 127.0.0.1 instead of localhost.

### DIFF
--- a/lib/guard/rspec/runner.rb
+++ b/lib/guard/rspec/runner.rb
@@ -167,7 +167,7 @@ module Guard
         # Make sure we have a listener running
         unless @drb_listener_running
           begin
-            DRb.start_service("druby://localhost:0")
+            DRb.start_service("druby://127.0.0.1:0")
           rescue SocketError, Errno::EADDRNOTAVAIL
             DRb.start_service("druby://:0")
           end


### PR DESCRIPTION
The DRb mode fails on OSX when something has required resolv-replace. For example:

Running tests with args ["--drb", "-f", "progress", "-r", "/usr/local/Cellar/ruby/2.0.0-p0/lib/ruby/gems/2.0.0/gems/guard-rspec-2.5.2/lib/guard/rspec/formatter.rb", "-f", "Guard::RSpec::Formatter", "--failure-exit-code", "2", "spec/unit/models/user_spec.rb"]...
Exception encountered: #<DRb::DRbConnError: druby://localhost:65076 - #<Errno::ECONNREFUSED: Connection refused - connect(2)>>

The issue appears to be differing resolution of 'localhost' (returning an IPv4 vs IPv6 address), and simply replacing 'localhost' with 127.0.0.1 avoids the problem.
