### PR TITLE
Fixed run_all parallel capability to run in parallel only when doing run_all.

### DIFF
--- a/lib/guard/rspec.rb
+++ b/lib/guard/rspec.rb
@@ -32,7 +32,7 @@ module Guard
     end
 
     def run_all
-      passed = @runner.run(@inspector.spec_paths, @options[:run_all].merge(:message => 'Running all specs'))
+      passed = @runner.run(@inspector.spec_paths, @options[:run_all].merge(:message => 'Running all specs', :run_all_specs => true))
 
       unless @last_failed = !passed
         @failed_paths = []

--- a/lib/guard/rspec/runner.rb
+++ b/lib/guard/rspec/runner.rb
@@ -53,8 +53,8 @@ module Guard
         end
       end
 
-      def rspec_executable
-        command = parallel? ? 'parallel_rspec' : 'rspec'
+      def rspec_executable(runtime_options = {})
+        command = parallel?(runtime_options) ? 'parallel_rspec' : 'rspec'
         @rspec_executable ||= (binstubs? && !executable_prefix?) ? "#{binstubs}/#{command}" : command
       end
 
@@ -118,9 +118,9 @@ module Guard
         cmd_parts << bin_command('foreman run') if foreman?
         cmd_parts << "bundle exec" if bundle_exec?
         cmd_parts << executable_prefix if executable_prefix?
-        cmd_parts << rspec_executable
-        cmd_parts << rspec_arguments(paths, options) if !parallel?
-        cmd_parts << parallel_rspec_arguments(paths, options) if parallel?
+        cmd_parts << rspec_executable(options)
+        cmd_parts << rspec_arguments(paths, options) if !parallel?(options)
+        cmd_parts << parallel_rspec_arguments(paths, options) if parallel?(options)
         cmd_parts.compact.join(' ')
       end
 
@@ -213,9 +213,12 @@ module Guard
         options.fetch(:zeus, false)
       end
 
-      def parallel?
-        parallel = options.fetch(:parallel, false)
-        (run_all = options[:run_all]) ? (run_all[:parallel] || parallel) : parallel
+      def parallel?(runtime_options = {})
+        if runtime_options[:run_all_specs]
+          runtime_options[:parallel]
+        else
+          options.fetch(:parallel, false)
+        end
       end
 
       def spring?

--- a/spec/guard/rspec/runner_spec.rb
+++ b/spec/guard/rspec/runner_spec.rb
@@ -627,9 +627,10 @@ describe Guard::RSpec::Runner do
           end
         end
 
-        describe ':run_all' do
-          context ':parallel => true' do
-            subject { described_class.new(:run_all => {:parallel => true}) }
+        describe ':run_all =>' do
+          context '{:parallel => true}' do
+            options = { :run_all => {:parallel => true} }
+            subject { described_class.new(options) }
 
             it 'runs with parallel_rspec' do
               subject.should_receive(:system).with(
@@ -637,7 +638,30 @@ describe Guard::RSpec::Runner do
                 "-o '-f progress -r #{@lib_path.join('guard/rspec/formatter.rb')} -f Guard::RSpec::Formatter --failure-exit-code 2' spec"
               ).and_return(true)
 
+              subject.run(['spec'], options[:run_all].merge(:run_all_specs => true))
+            end
+
+            it 'does not use parallel_rspec unless #run_all was called' do
+              subject.should_receive(:system).with(
+                "bundle exec rspec -f progress -r #{@lib_path.join('guard/rspec/formatter.rb')} " <<
+                '-f Guard::RSpec::Formatter --failure-exit-code 2 spec'
+              ).and_return(true)
+
               subject.run(['spec'])
+            end
+          end
+
+          context '{:parallel => false}' do
+            options = { :run_all => {:parallel => false} }
+            subject { described_class.new(options) }
+
+            it 'does not use parallel_rspec' do
+              subject.should_receive(:system).with(
+                "bundle exec rspec -f progress -r #{@lib_path.join('guard/rspec/formatter.rb')} " <<
+                '-f Guard::RSpec::Formatter --failure-exit-code 2 spec'
+              ).and_return(true)
+
+              subject.run(['spec'], options[:run_all].merge(:run_all_specs => true))
             end
           end
         end

--- a/spec/guard/rspec_spec.rb
+++ b/spec/guard/rspec_spec.rb
@@ -77,11 +77,17 @@ describe Guard::RSpec do
       subject.run_all
     end
 
+    it 'passes the :run_all_specs argument' do
+      runner.should_receive(:run).with(['spec'], (hash_including(:run_all_specs => true))) { true }
+
+      subject.run_all
+    end
+
     it 'passes the :run_all options' do
       subject = described_class.new([], {
-        :rvm => ['1.8.7', '1.9.2'], :cli => '--color', :run_all => { :cli => '--format progress' }
+        :rvm => ['1.8.7', '1.9.2'], :cli => '--color', :run_all => { :cli => '--format progress', :parallel => true, :parallel_cli => '-n 42' }
       })
-      runner.should_receive(:run).with(['spec'], hash_including(:cli => '--format progress')) { true }
+      runner.should_receive(:run).with(['spec'], hash_including(:cli => '--format progress', :parallel => true, :parallel_cli => '-n 42')) { true }
 
       subject.run_all
     end
@@ -215,7 +221,7 @@ describe Guard::RSpec do
 
         runner.should_receive(:run).with(['./a_spec.rb:1', './a_spec.rb:7']) { true }
         runner.should_receive(:run).with(['./a_spec.rb', './b_spec']) { true }
-        runner.should_receive(:run).with(['spec'], :message => "Running all specs") { true }
+        runner.should_receive(:run).with(['spec'], :message => "Running all specs", :run_all_specs => true) { true }
 
         @subject.run_on_changes(['./a_spec.rb','./b_spec'])
       end


### PR DESCRIPTION
If ":run_all => { :parallel => true }" is present but ":parallel => true..." is not, then only run in parallel when running all specs.
