### PR TITLE
fixes compatibility with guard-bundler gem

### DIFF
--- a/lib/guard/rspec/runner.rb
+++ b/lib/guard/rspec/runner.rb
@@ -50,8 +50,8 @@ module Guard
       end
 
       def _without_bundler_env
-        if defined?(Bundler)
-          Bundler.with_clean_env { yield }
+        if defined?(::Bundler)
+          ::Bundler.with_clean_env { yield }
         else
           yield
         end


### PR DESCRIPTION
Changes instances of Bundler to ::Bundler to prevent it from attempting
to reference Guard::Bundler.

When attempting to run with both gems installed, you would receive the following error:

```
Guard::RSpec failed to achieve its <run_all>, exception was:
> [#F722A29A3B60] NoMethodError: undefined method `with_clean_env' for Guard::Bundler:Class
```
