### PR TITLE
Fix guard notification settings

### DIFF
--- a/spec/lib/guard/rspec/runner_spec.rb
+++ b/spec/lib/guard/rspec/runner_spec.rb
@@ -107,6 +107,14 @@ describe Guard::RSpec::Runner do
       runner.run(paths)
     end
 
+    it "does not clobber GUARD ENV vars" do
+      ENV['GUARD_NOTIFY'] = 'true'
+      Kernel.should_receive(:system) do
+        expect(ENV['GUARD_NOTIFY']).to eq 'true'
+      end
+      runner.run(paths)
+    end
+
     context "with all_after_pass option and old failed spec paths" do
       let(:options) { { all_after_pass: true } }
       before {


### PR DESCRIPTION
::Bundler.with_clean_env is clobbering the `GUARD_NOTIFY` and `GUARD_NOTIFIERS`
environment variables needed for notification settings. This change resets
guard related environment variables that have been reset by Bundler.

I think this addresses the same issue as #217, although #217 also contains a bunch of refactors.
