### PR TITLE
fix 'deprectated' typo

### DIFF
--- a/lib/guard/rspec/deprecator.rb
+++ b/lib/guard/rspec/deprecator.rb
@@ -29,32 +29,32 @@ module Guard
 
       def _version_option
         return unless options.key?(:version)
-        _deprectated('The :version option is deprecated. Only RSpec ~> 2.14 is now supported.')
+        _deprecated('The :version option is deprecated. Only RSpec ~> 2.14 is now supported.')
       end
 
       def _exclude_option
         return unless options.key?(:exclude)
-        _deprectated('The :exclude option is deprecated. Please Guard ignore method instead. https://github.com/guard/guard#ignore')
+        _deprecated('The :exclude option is deprecated. Please Guard ignore method instead. https://github.com/guard/guard#ignore')
       end
 
       def _use_cmd_option
         %w[color drb fail_fast formatter env bundler binstubs rvm cli spring turnip zeus foreman].each do |option|
           next unless options.key?(option.to_sym)
-          _deprectated("The :#{option} option is deprecated. Please customize the new :cmd option to fit your need.")
+          _deprecated("The :#{option} option is deprecated. Please customize the new :cmd option to fit your need.")
         end
       end
 
       def _keep_failed_option
         return unless options.key?(:keep_failed)
-        _deprectated('The :keep_failed option is deprecated. Please set new :failed_mode option value to :keep instead. https://github.com/guard/guard-rspec#list-of-available-options')
+        _deprecated('The :keep_failed option is deprecated. Please set new :failed_mode option value to :keep instead. https://github.com/guard/guard-rspec#list-of-available-options')
       end
 
       def _focus_on_failed_option
         return unless options.key?(:focus_on_failed)
-        _deprectated('The :focus_on_failed option is deprecated. Focus mode is the default and can be changed using new :failed_mode option. https://github.com/guard/guard-rspec#list-of-available-options')
+        _deprecated('The :focus_on_failed option is deprecated. Focus mode is the default and can be changed using new :failed_mode option. https://github.com/guard/guard-rspec#list-of-available-options')
       end
 
-      def _deprectated(message)
+      def _deprecated(message)
         UI.warning %{Guard::RSpec DEPRECATION WARNING: #{message}}
       end
 


### PR DESCRIPTION
I was tracking down a problem with my custom Pry commands and I ran across this typo.
