### PR TITLE
Fix #222

### DIFF
--- a/lib/guard/rspec/formatter.rb
+++ b/lib/guard/rspec/formatter.rb
@@ -1,3 +1,4 @@
+require 'guard/rspec'
 require 'rspec/core/formatters/base_formatter'
 
 module Guard


### PR DESCRIPTION
Guard-rspec's formatter required by RSpec runner defines Guard::RSpec class
without parent, so Object becomes the parent instead of Guard::Plugin.

Fix: require 'guard/rspec' in 'guard/rspec/formatter' explicitly.
