### PR TITLE
Allow prereleases of rspec 3.0.0

### DIFF
--- a/guard-rspec.gemspec
+++ b/guard-rspec.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.add_dependency 'guard', '>= 2.1.1'
-  s.add_dependency 'rspec', '>= 2.14', '< 4.0'
+  s.add_dependency 'rspec', '>= 2.14', '~> 3.0.0.beta', '< 4.0'
   s.add_development_dependency 'bundler', '>= 1.3.5'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
If you use guard-rspec with rspec 3.0.0.beta1, bundler will downgrade guard-rspec all the way down to 1.2.1 because that was the last version that didn't specify a dependency on rspec. 1.2.1 works just fine for most purposes, but I couldn't figure out how to use it with [spring](https://github.com/jonleighton/spring) without the `cmd` parameter. This commit allows us to use guard-rspec with prereleases of rspec 3.0.0 until such time as it is stable.
