### PR TITLE
Don't fail when there are no spec files to be run

### DIFF
--- a/lib/guard/rspec/runner.rb
+++ b/lib/guard/rspec/runner.rb
@@ -17,14 +17,14 @@ module Guard
       def run_all
         paths = options[:spec_paths]
         options = @options.merge(@options[:run_all]).freeze
-        return if paths.empty?
+        return true if paths.empty?
         ::Guard::UI.info(options[:message], reset: true)
         _run(true, paths, options)
       end
 
       def run(paths)
         paths = inspector.paths(paths)
-        return if paths.empty?
+        return true if paths.empty?
         ::Guard::UI.info("Running: #{paths.join(' ')}", reset: true)
         _run(false, paths, options)
       end

--- a/spec/lib/guard/rspec/runner_spec.rb
+++ b/spec/lib/guard/rspec/runner_spec.rb
@@ -40,6 +40,17 @@ describe Guard::RSpec::Runner do
     end
   end
 
+  shared_examples 'abort' do
+    it 'aborts' do
+      expect(Guard::UI).to_not receive(:info)
+      subject
+    end
+
+    it 'returns true' do
+      expect(subject).to be true
+    end
+  end
+
   describe '#run_all' do
     let(:options) { {
       spec_paths: %w[spec1 spec2],
@@ -54,6 +65,17 @@ describe Guard::RSpec::Runner do
     it 'prints message' do
       expect(Guard::UI).to receive(:info).with('Custom message', reset: true)
       runner.run_all
+    end
+
+    context 'when no paths are given' do
+      subject { runner.run_all }
+
+      let(:options) { {
+        spec_paths: [],
+        run_all: { message: 'Custom message' }
+      } }
+
+      include_examples 'abort'
     end
 
     context 'with custom cmd' do
@@ -82,10 +104,14 @@ describe Guard::RSpec::Runner do
       runner.run(paths)
     end
 
-    it 'returns if no paths are given' do
-      allow(inspector).to receive(:paths) { [] }
-      expect(Guard::UI).to_not receive(:info)
-      runner.run([])
+    context 'when no paths are given' do
+      subject { runner.run([]) }
+
+      before do
+        allow(inspector).to receive(:paths) { [] }
+      end
+
+      include_examples 'abort'
     end
 
     it 'builds commands with spec paths' do


### PR DESCRIPTION
Currently `guard-rspec` throws `:task_has_failed` when there are no spec files to be run.
This change makes `guard-rspec` abort without failing in that case.
## Example

Here's an `Guardfile` with a group with `halt_on_fail` option:

``` ruby
# This group allows to skip running RuboCop when RSpec failed.
group :red_green_refactor, halt_on_fail: true do
  guard :rspec, cmd: 'bundle exec rspec' do
    watch(%r{^spec/.+_spec\.rb$})
    watch(%r{^lib/(.+)\.rb$}) { |m| "spec/#{m[1]}_spec.rb" }
  end

  guard :rubocop do
    watch(%r{.+\.rb$})
  end
end
```

When I modified a library file that has no corresponding spec file (i.e. `lib/foo.rb` exists but `spec/foo_spec.rb` doesn't exist), `guard-rspec` fails and `guard-rubocop` won't run.

```
$ bundle exec guard --debug
23:33:15 - DEBUG - Command execution: emacsclient --eval '1' 2> /dev/null || echo 'N/A'
23:33:15 - INFO - Guard is using GNTP to send notifications.
23:33:15 - INFO - Guard is using TerminalTitle to send notifications.
23:33:15 - DEBUG - Command execution: hash stty
23:33:15 - DEBUG - Guard starts all plugins
23:33:15 - DEBUG - Hook :start_begin executed for Guard::RSpec
23:33:15 - INFO - Guard::RSpec is running
23:33:15 - DEBUG - Hook :start_end executed for Guard::RSpec
23:33:15 - DEBUG - Hook :start_begin executed for Guard::Rubocop
23:33:15 - DEBUG - Hook :start_end executed for Guard::Rubocop
23:33:15 - DEBUG - Hook :start_begin executed for Guard::Shell
23:33:15 - DEBUG - Hook :start_end executed for Guard::Shell
23:33:15 - INFO - Guard is now watching at '/tmp/transpec'
23:33:15 - DEBUG - Command execution: stty -g 2>/dev/null
23:33:15 - DEBUG - Start interactor
23:33:32 - DEBUG - Stop interactor
23:33:32 - DEBUG - Command execution: stty gfmt1:cflag=4b00:iflag=6b02:lflag=200005cb:oflag=3:discard=f:dsusp=19:eof=4:eol=ff:eol2=ff:erase=7f:intr=3:kill=15:lnext=16:min=1:quit=1c:reprint=12:start=11:status=14:stop=13:susp=1a:time=0:werase=17:ispeed=9600:ospeed=9600 2>/dev/null 
23:33:32 - DEBUG - Hook :run_on_modifications_begin executed for Guard::RSpec
23:33:32 - INFO - Guard::RSpec has failed, other group's plugins execution has been halted.
23:33:32 - DEBUG - Command execution: stty -g 2>/dev/null
23:33:32 - DEBUG - Start interactor
```

Actually I'm still not sure whether this is a specification or a bug, though I feel this is strange and inconvenient.
What do you think?
## Environment
- ruby 2.0.0p353 (2013-11-22 revision 43784) [x86_64-darwin13.0.0]
- `guard` 2.2.5
- `guard-rspec` 4.2.0

Gemfile:

``` ruby
source 'https://rubygems.org'

gem 'guard-rspec',   '~> 4.0'
gem 'guard-rubocop', '~> 1.0'
```
