### PR TITLE
Fix dependencies

### DIFF
--- a/guard-rspec.gemspec
+++ b/guard-rspec.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |s|
   s.test_files   = s.files.grep(%r{^spec/})
   s.require_path = 'lib'
 
-  s.add_dependency 'guard', '~> 2.1', '>= 2.1'
+  s.add_dependency 'guard', '~> 2.1'
   s.add_dependency 'rspec', '>= 2.14', '< 4.0'
 
-  s.add_development_dependency 'bundler', '~> 1.3', '>= 1.3.5'
+  s.add_development_dependency 'bundler', '>= 1.3.5', '< 2.0'
   s.add_development_dependency 'rake', '~> 10.1'
   s.add_development_dependency 'launchy', '~> 2.4'
 end


### PR DESCRIPTION
## Problem

With the current `rspec` dependency definition in `guard-rspec`:

``` ruby
s.add_dependency 'rspec', '>= 2.14', '~> 3.0.0.beta', '< 4.0'
```

And a `Gemfile` in another project:

``` ruby
gem 'rspec', '~> 2.14'
gem 'guard-rspec', '~> 4.2.2'
```

Then run Bundler:

``` bash
$ bundle update
Fetching gem metadata from https://rubygems.org/.........
Fetching additional metadata from https://rubygems.org/..
Resolving dependencies...
Bundler could not find compatible versions for gem "rspec":
  In Gemfile:
    rspec (~> 2.14) ruby

    guard-rspec (~> 4.2.2) ruby depends on
      rspec (3.0.0.beta1)
```

This means the `~> 3.0.0.beta` negates the `>= 2.14`.
## Solution

If `guard-rspec` defines:

``` ruby
s.add_dependency 'rspec', '>= 2.14', '< 4.0'
```

Then this works in another project:

``` ruby
gem 'rspec', '~> 2.14'
gem 'guard-rspec', '~> 4.2.2'
```

And this also works:

``` ruby
gem 'rspec', '~> 3.0.0.beta1'
gem 'guard-rspec', '~> 4.2.2'
```

I've tested these behavior with [my gem](https://github.com/yujinakayama/test_site/blob/v0.0.2/test_site.gemspec#L21).

This fixes #235.
