### PR TITLE
Add `bundle exec` instructions to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ guard :rspec, cmd: 'spring rspec -f doc' do
 end
 ```
 
+### Running with bundler
+
+Running `bundle exec guard` will not run the specs with bundler. You need to change `cmd` the option to include `bundle exec`:
+
+``` ruby
+guard :rspec, cmd: 'bundle exec guard' do
+  # ...
+end
+```
+
 ### List of available options:
 
 ``` ruby


### PR DESCRIPTION
Added instructions for running with bundler to avoid issues like https://github.com/guard/guard-rspec/issues/237
