### PR TITLE
Speeds up guard quite a bit for large projects.

### DIFF
--- a/lib/guard/rspec/templates/Guardfile
+++ b/lib/guard/rspec/templates/Guardfile
@@ -1,3 +1,5 @@
+ignore([%r{^bin/*}, %r{^config/*}, %r{^db/*}, %r{^lib/*}, %r{^log/*}, %r{^public/*}, %r{^tmp/*}])
+
 guard :rspec do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }


### PR DESCRIPTION
I added an ignore for some rather large directories that shouldn't really be watched by Guard. This prevents my CPU from idiling at 100% while running guard. Courtesy of pangdudu at SO.
