### PR TITLE
fixed formatter.rb:7 warning: already initialized constant TEMPORARY_FIL...

### DIFF
--- a/lib/guard/rspec/formatter.rb
+++ b/lib/guard/rspec/formatter.rb
@@ -4,7 +4,7 @@ require 'rspec/core/formatters/base_formatter'
 module Guard
   class RSpec
     class Formatter < ::RSpec::Core::Formatters::BaseFormatter
-      TEMPORARY_FILE_PATH = File.expand_path('./tmp/rspec_guard_result')
+      TEMPORARY_FILE_PATH ||= File.expand_path('./tmp/rspec_guard_result')
 
       def self.rspec_3?
         ::RSpec::Core::Version::STRING.split('.').first == "3"


### PR DESCRIPTION
guard-rspec in jruby out

```
guard-rspec-4.2.8/lib/guard/rspec/formatter.rb:7 warning: already initialized constant TEMPORARY_FILE_PATH
```

fixed this bug
