### PR TITLE
Updated Guardfile template so that Guard can watch the new rails helper file.

### DIFF
--- a/lib/guard/rspec/templates/Guardfile
+++ b/lib/guard/rspec/templates/Guardfile
@@ -10,6 +10,7 @@ guard :rspec do
   watch(%r{^spec/support/(.+)\.rb$})                  { "spec" }
   watch('config/routes.rb')                           { "spec/routing" }
   watch('app/controllers/application_controller.rb')  { "spec/controllers" }
+  watch('spec/rails_helper.rb')                       { "spec" }
 
   # Capybara features specs
   watch(%r{^app/views/(.+)/.*\.(erb|haml|slim)$})     { |m| "spec/features/#{m[1]}_spec.rb" }


### PR DESCRIPTION
rspec-rails v3.0.0 generate the new rails helper file.

[rspec-rails Changelog.md#300--2014-06-01](https://github.com/rspec/rspec-rails/blob/master/Changelog.md#300--2014-06-01)

> Separate RSpec configuration in generated spec_helper from Rails setup and associated configuration options. Moving Rails specific settings and options to rails_helper. (Aaron Kromer)

Updated Guardfile template so that Guard can watch it.
