### PR TITLE
Add Ruby 2.1.2 to list of rubies tested against

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Guard::RSpec allows to automatically & intelligently launch specs when files are modified.
 
 * Compatible with RSpec >2.14 & 3
-* Tested against Ruby 1.9.3, 2.0.0, JRuby and Rubinius.
+* Tested against Ruby 1.9.3, 2.0.0, 2.1.2, JRuby and Rubinius.
 
 ## Install
 


### PR DESCRIPTION
I saw it in the .travis.yml file, so I assume it should be included in the README
