### PR TITLE
Fixed watchdir option

### DIFF
--- a/lib/guard/rspec/command.rb
+++ b/lib/guard/rspec/command.rb
@@ -1,5 +1,5 @@
-require 'rspec/core'
-require 'pathname'
+require "rspec/core"
+require "pathname"
 
 module Guard
   class RSpec
@@ -11,7 +11,7 @@ module Guard
       def initialize(paths, options = {})
         @paths = paths
         @options = options
-        super(_parts.join(' '))
+        super(_parts.join(" "))
       end
 
       private
@@ -22,12 +22,17 @@ module Guard
         parts << _guard_formatter
         parts << "--failure-exit-code #{FAILURE_EXIT_CODE}"
         parts << options[:cmd_additional_args] || ""
-        parts << paths.join(' ')
+        if chdir = options[:chdir]
+          paths.each do |path|
+            path.sub!("#{chdir}#{File::SEPARATOR}", "")
+          end
+        end
+        parts << paths.join(" ")
       end
 
       def _visual_formatter
         return if _cmd_include_formatter?
-        _rspec_formatters || '-f progress'
+        _rspec_formatters || "-f progress"
       end
 
       def _rspec_formatters
@@ -36,9 +41,9 @@ module Guard
         config = ::RSpec::Core::ConfigurationOptions.new([])
         config.parse_options if config.respond_to?(:parse_options)
         formatters = config.options[:formatters] || nil
-        # RSpec's parser returns an array in the format [[formatter, output], ...], so match their format
+        # RSpec"s parser returns an array in the format [[formatter, output], ...], so match their format
         # Construct a matching command line option, including output target
-        formatters && formatters.map { |formatter| "-f #{formatter.join ' -o '}" }.join(' ')
+        formatters && formatters.map { |formatter| "-f #{formatter.join " -o "}" }.join(" ")
       end
 
       def _cmd_include_formatter?

--- a/lib/guard/rspec/formatter.rb
+++ b/lib/guard/rspec/formatter.rb
@@ -1,13 +1,13 @@
-require 'guard/rspec'
-require 'rspec/core/formatters/base_formatter'
+require "guard/rspec"
+require "rspec/core/formatters/base_formatter"
 
 module Guard
   class RSpec
     class Formatter < ::RSpec::Core::Formatters::BaseFormatter
-      TEMPORARY_FILE_PATH ||= File.expand_path('./tmp/rspec_guard_result')
+      TEMPORARY_FILE_PATH ||= "./tmp/rspec_guard_result"
 
       def self.rspec_3?
-        ::RSpec::Core::Version::STRING.split('.').first == "3"
+        ::RSpec::Core::Version::STRING.split(".").first == "3"
       end
 
       if rspec_3?
@@ -20,6 +20,22 @@ module Guard
         def examples
           @examples ||= []
         end
+      end
+
+      def self.paths_with_chdir(paths, chdir)
+        paths.map do |path|
+          path_with_chdir(path, chdir)
+        end
+      end
+
+      def self.path_with_chdir(path, chdir)
+        return path unless chdir
+
+        File.join(chdir, path)
+      end
+
+      def self.tmp_file(chdir)
+        path_with_chdir(TEMPORARY_FILE_PATH, chdir)
       end
 
       # rspec issue https://github.com/rspec/rspec-core/issues/793
@@ -35,7 +51,7 @@ module Guard
             return root_metadata[:location]
           end
 
-          location = (metadata[:location] || "").split(':').first # rspec issue https://github.com/rspec/rspec-core/issues/1243
+          location = (metadata[:location] || "").split(":").first # rspec issue https://github.com/rspec/rspec-core/issues/1243
         end
 
         location
@@ -47,7 +63,7 @@ module Guard
         if File.const_defined?(:FNM_EXTGLOB) # ruby >= 2
           flags |= File::FNM_EXTGLOB
         end
-        File.fnmatch(::RSpec.configuration.pattern, path.sub(/:\d+\z/, ''), flags)
+        File.fnmatch(::RSpec.configuration.pattern, path.sub(/:\d+\z/, ""), flags)
       end
 
       def dump_summary(*args)
@@ -63,7 +79,7 @@ module Guard
           write_summary(*args)
         end
       rescue
-        # nothing really we can do, at least don't kill the test runner
+        # nothing really we can do, at least don"t kill the test runner
       end
 
       # Write summary to temporary file for runner
@@ -77,12 +93,13 @@ module Guard
       private
 
       def _write(&block)
-        FileUtils.mkdir_p(File.dirname(TEMPORARY_FILE_PATH))
-        File.open(TEMPORARY_FILE_PATH, 'w', &block)
+        file = File.expand_path(TEMPORARY_FILE_PATH)
+        FileUtils.mkdir_p(File.dirname(file))
+        File.open(file, "w", &block)
       end
 
       def _failed_paths
-        failed = examples.select { |e| e.execution_result[:status].to_s == 'failed' }
+        failed = examples.select { |e| e.execution_result[:status].to_s == "failed" }
         failed.map { |e| self.class.extract_spec_location(e.metadata) }.sort.uniq
       end
 

--- a/lib/guard/rspec/inspectors/base_inspector.rb
+++ b/lib/guard/rspec/inspectors/base_inspector.rb
@@ -7,6 +7,7 @@ module Guard
         def initialize(options = {})
           @options = options
           @spec_paths = @options[:spec_paths]
+          @chdir = @options[:chdir]
         end
 
         def paths(paths)
@@ -33,18 +34,36 @@ module Guard
           paths.compact!
           spec_dirs = _select_only_spec_dirs(paths)
           spec_files = _select_only_spec_files(paths)
-          spec_dirs + spec_files
+          (spec_dirs + spec_files).uniq
         end
 
         def _select_only_spec_dirs(paths)
-          paths.select { |p| File.directory?(p) || spec_paths.include?(p) }
+          paths.select do |path|
+            File.directory?(path) ||
+              _spec_paths_with_chdir.include?(path)
+          end
         end
 
         def _select_only_spec_files(paths)
-          spec_files = spec_paths.collect { |path| Dir[File.join(path, "**{,/*/**}", "*[_.]spec.rb")] }
-          feature_files = spec_paths.collect { |path| Dir[File.join(path, "**{,/*/**}", "*.feature")] }
+          spec_files = _collect_files("*[_.]spec.rb")
+          feature_files = _collect_files("*.feature")
           files = (spec_files + feature_files).flatten
-          paths.select { |p| files.include?(p) }
+
+          paths.select do |path|
+            files.any? do |file|
+              file == Formatter.path_with_chdir(path, @chdir)
+            end
+          end
+        end
+
+        def _spec_paths_with_chdir
+          Formatter.paths_with_chdir(spec_paths, @chdir)
+        end
+
+        def _collect_files(pattern)
+          _spec_paths_with_chdir.collect do |path|
+            Dir[File.join(path, "**{,/*/**}", pattern)]
+          end
         end
       end
     end

--- a/lib/guard/rspec/runner.rb
+++ b/lib/guard/rspec/runner.rb
@@ -76,13 +76,16 @@ module Guard
       end
 
       def _command_output
-        formatter_tmp_file = Formatter::TEMPORARY_FILE_PATH
+        formatter_tmp_file = Formatter.tmp_file(options[:chdir])
         lines = File.readlines(formatter_tmp_file)
-        [lines.first.strip, lines[1..11].map(&:strip).compact]
+        summary = lines.first.strip
+        failed_paths = lines[1..11].map(&:strip).compact
+
+        [summary, failed_paths]
       rescue
         [nil, nil]
       ensure
-        File.exist?(formatter_tmp_file) && File.delete(formatter_tmp_file)
+        File.delete(formatter_tmp_file) if File.exists?(formatter_tmp_file)
       end
 
       def _open_launchy

--- a/spec/lib/guard/rspec/command_spec.rb
+++ b/spec/lib/guard/rspec/command_spec.rb
@@ -58,6 +58,26 @@ describe Guard::RSpec::Command do
         expect(command).to match %r{-f progress}
       end
     end
+
+    context ":chdir option present" do
+      let(:chdir) { "moduleA" }
+      let(:paths) do
+        %w[path1 path2].map { |p| "#{chdir}#{File::Separator}#{p}" }
+      end
+
+      let(:options) do
+        {
+          cmd: "cd #{chdir} && rspec",
+          chdir: chdir
+        }
+      end
+
+      it "removes chdir part from the path
+        as it should be present in the cmd" do
+
+        expect(command).to match %r{path1 path2}
+      end
+    end
   end
 
 end

--- a/spec/lib/guard/rspec/formatter_spec.rb
+++ b/spec/lib/guard/rspec/formatter_spec.rb
@@ -1,16 +1,54 @@
-require 'spec_helper.rb'
-require 'guard/rspec/formatter'
+require "spec_helper.rb"
+require "guard/rspec/formatter"
 
 describe Guard::RSpec::Formatter do
-  describe '::TEMPORARY_FILE_PATH' do
-    it 'is absolute path' do
-      require 'pathname'
-      temporary_file_path = described_class.const_get(:TEMPORARY_FILE_PATH)
-      expect(Pathname.new(temporary_file_path).absolute?).to eq(true)
+
+  describe "::TEMPORARY_FILE_PATH" do
+    require "pathname"
+    let(:temporary_file_path) { described_class::TEMPORARY_FILE_PATH }
+
+    subject { Pathname.new(temporary_file_path).absolute? }
+
+    it "is relative path" do
+      expect(subject).to eq(false)
     end
   end
 
-  describe '#write_summary' do
+  describe ".tmp_file" do
+    let(:chdir) { nil }
+
+    subject { described_class.tmp_file(chdir) }
+
+    it { expect(subject).to eq(described_class::TEMPORARY_FILE_PATH) }
+
+    context "chdir option present" do
+      let(:chdir) { "moduleA" }
+
+      it do
+        expect(subject).to eq(
+          "#{chdir}/#{described_class::TEMPORARY_FILE_PATH}")
+      end
+    end
+  end
+
+  describe ".paths_with_chdir" do
+    let(:paths) { %w[path1 path2] }
+    let(:chdir) { nil }
+
+    subject { described_class.paths_with_chdir(paths, chdir) }
+
+    it { expect(subject).to eq(paths) }
+
+    context "chdir option present" do
+      let(:chdir) { "moduleA" }
+
+      it do
+        expect(subject).to eq(paths.map { |p| "#{chdir}/#{p}" })
+      end
+    end
+  end
+
+  describe "#write_summary" do
     let(:writer) {
       StringIO.new
     }
@@ -26,38 +64,46 @@ describe Guard::RSpec::Formatter do
       writer.read
     }
 
-    context 'without stubbed IO' do
+    context "without stubbed IO" do
       let(:formatter) {
         Guard::RSpec::Formatter.new(StringIO.new)
       }
 
-      it 'creates temporary file and and writes to it' do
-        temporary_file_path = described_class.const_get(:TEMPORARY_FILE_PATH)
-        expect(FileUtils).to receive(:mkdir_p).with(File.dirname(temporary_file_path)) {}
-        expect(File).to receive(:open).with(temporary_file_path, 'w') { |filename, mode, &block| block.call writer }
+      it "creates temporary file and and writes to it" do
+        file = File.expand_path(described_class::TEMPORARY_FILE_PATH)
+        expect(FileUtils).to receive(:mkdir_p).
+          with(File.dirname(file)) {}
+        expect(File).to receive(:open).
+          with(file, "w") do |_, _, &block|
+          block.call writer
+        end
         formatter.write_summary(123, 1, 2, 3)
       end
     end
 
-    context 'with failures' do
+    context "with failures" do
       let(:spec_filename) {
-        'failed_location_spec.rb'
+        "failed_location_spec.rb"
       }
       let(:failed_example) { double(
-        execution_result: { status: 'failed' },
+        execution_result: { status: "failed" },
         metadata: { location: spec_filename }
       ) }
 
-      it 'writes summary line and failed location in tmp dir' do
-        allow(formatter).to receive(:examples) { [failed_example] }
-        formatter.write_summary(123, 3, 1, 0)
-        expect(result).to match /^3 examples, 1 failures in 123\.0 seconds\n#{spec_filename}\n$/
+      def expected_output(spec_filename)
+        /^3 examples, 1 failures in 123\.0 seconds\n#{spec_filename}\n$/
       end
 
-      it 'writes only uniq filenames out' do
+      it "writes summary line and failed location in tmp dir" do
+        allow(formatter).to receive(:examples) { [failed_example] }
+        formatter.write_summary(123, 3, 1, 0)
+        expect(result).to match expected_output(spec_filename)
+      end
+
+      it "writes only uniq filenames out" do
         allow(formatter).to receive(:examples) { [failed_example, failed_example] }
         formatter.write_summary(123, 3, 1, 0)
-        expect(result).to match /^3 examples, 1 failures in 123\.0 seconds\n#{spec_filename}\n$/
+        expect(result).to match expected_output(spec_filename)
       end
 
       context "for rspec 3" do
@@ -68,36 +114,37 @@ describe Guard::RSpec::Formatter do
           allow(formatter.class).to receive(:rspec_3?).and_return(true)
         end
 
-        it 'writes summary line and failed location' do
+        it "writes summary line and failed location" do
           allow(formatter).to receive(:examples) { [failed_example] }
           formatter.dump_summary(notification)
-          expect(result).to match /^3 examples, 1 failures in 123\.0 seconds\n#{spec_filename}\n$/
+          expect(result).to match expected_output(spec_filename)
         end
       end
     end
 
-    it 'should find the spec file for shared examples' do
+    it "should find the spec file for shared examples" do
       metadata = {
-        location: './spec/support/breadcrumbs.rb:75',
-        example_group: { location: './spec/requests/breadcrumbs_spec.rb:218' }
+        location: "./spec/support/breadcrumbs.rb:75",
+        example_group: { location: "./spec/requests/breadcrumbs_spec.rb:218" }
       }
 
-      expect(described_class.extract_spec_location(metadata)).to start_with './spec/requests/breadcrumbs_spec.rb'
+      result = described_class.extract_spec_location(metadata)
+      expect(result).to start_with "./spec/requests/breadcrumbs_spec.rb"
     end
 
     # Skip location because of rspec issue https://github.com/rspec/rspec-core/issues/1243
-    it 'should return only the spec file without line number for shared examples' do
+    it "should return only the spec file without line number for shared examples" do
       metadata = {
-        location: './spec/support/breadcrumbs.rb:75',
-        example_group: { location: './spec/requests/breadcrumbs_spec.rb:218' }
+        location: "./spec/support/breadcrumbs.rb:75",
+        example_group: { location: "./spec/requests/breadcrumbs_spec.rb:218" }
       }
 
-      expect(described_class.extract_spec_location(metadata)).to eq './spec/requests/breadcrumbs_spec.rb'
+      expect(described_class.extract_spec_location(metadata)).to eq "./spec/requests/breadcrumbs_spec.rb"
     end
 
-    it 'should return location of the root spec when a shared examples has no location' do
+    it "should return location of the root spec when a shared examples has no location" do
       metadata = {
-        location: './spec/support/breadcrumbs.rb:75',
+        location: "./spec/support/breadcrumbs.rb:75",
         example_group: {}
       }
 
@@ -105,14 +152,14 @@ describe Guard::RSpec::Formatter do
       expect(described_class.extract_spec_location(metadata)).to eq metadata[:location]
     end
 
-    context 'with only success' do
-      it 'notifies success' do
+    context "with only success" do
+      it "notifies success" do
         formatter.write_summary(123, 3, 0, 0)
         expect(result).to match /^3 examples, 0 failures in 123\.0 seconds\n$/
       end
     end
 
-    context 'with pending' do
+    context "with pending" do
       it "notifies pending too" do
         formatter.write_summary(123, 3, 0, 1)
         expect(result).to match /^3 examples, 0 failures \(1 pending\) in 123\.0 seconds\n$/

--- a/spec/lib/guard/rspec/inspectors/base_inspector_spec.rb
+++ b/spec/lib/guard/rspec/inspectors/base_inspector_spec.rb
@@ -1,33 +1,108 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Guard::RSpec::Inspectors::BaseInspector do
-  let(:options) { { custom: 'value', spec_paths: %w[myspec] } }
+  let(:options) { { custom: "value", spec_paths: %w[myspec] } }
   let(:inspector) { Guard::RSpec::Inspectors::BaseInspector.new(options) }
   let(:paths) { %w[spec/foo_spec.rb spec/bar_spec.rb] }
-  let(:abstract_error) { 'Must be implemented in subclass' }
+  let(:abstract_error) { "Must be implemented in subclass" }
 
-  describe '.initialize' do
-    it 'sets options and spec_paths' do
+  describe ".initialize" do
+    it "sets options and spec_paths" do
       expect(inspector.options).to include(:custom, :spec_paths)
-      expect(inspector.options[:custom]).to eq('value')
+      expect(inspector.options[:custom]).to eq("value")
       expect(inspector.spec_paths).to eq(%w[myspec])
     end
   end
 
-  describe '#paths' do
-    it 'should not be emplemented here' do
+  describe "#paths" do
+    it "should not be implemented here" do
       expect { inspector.paths(paths) }.to raise_error(abstract_error)
+    end
+
+    context "specific inspector" do
+      class FooInspector < Guard::RSpec::Inspectors::BaseInspector
+        def paths(paths)
+          _clean(paths)
+        end
+      end
+
+      let(:options) do
+        {
+          chdir: chdir,
+          spec_paths: ["spec"]
+        }
+      end
+      let(:chdir) { nil }
+      let(:inspector) { FooInspector.new(options) }
+
+      subject { inspector.paths(paths) }
+
+      context "_select_only_spec_dirs" do
+        let(:paths) { ["spec"] }
+
+        it "returns matching paths" do
+          allow(File).to receive(:directory?).
+            with("spec").and_return(false)
+
+          expect(subject).to eq(paths)
+        end
+
+        context "chdir option present" do
+          let(:chdir) { "moduleA" }
+          let(:paths) { ["#{chdir}/spec"] }
+
+          it "returns matching paths" do
+            allow(File).to receive(:directory?).
+              with("moduleA/spec").and_return(false)
+
+            expect(subject).to eq(paths)
+          end
+        end
+      end
+
+      context "_select_only_spec_files" do
+        let(:paths) do
+          ["app/models/a_foo.rb", "spec/models/a_foo_spec.rb"]
+        end
+        let(:spec_files) do
+          [["spec/models/a_foo_spec.rb",
+            "spec/models/b_foo_spec.rb"]]
+        end
+
+        before do
+          allow(Dir).to receive(:[]).and_return(spec_files)
+        end
+
+        it "returns matching paths" do
+          expect(subject).to eq(["spec/models/a_foo_spec.rb"])
+        end
+
+        context "chdir option present" do
+          let(:chdir) { "moduleA" }
+          let(:paths) do
+            ["moduleA/models/a_foo.rb", "spec/models/a_foo_spec.rb"]
+          end
+          let(:spec_files) do
+            [["moduleA/spec/models/a_foo_spec.rb",
+              "moduleA/spec/models/b_foo_spec.rb"]]
+          end
+
+          it "returns matching paths" do
+            expect(subject).to eq(["spec/models/a_foo_spec.rb"])
+          end
+        end
+      end
     end
   end
 
-  describe '#failed' do
-    it 'should not be emplemented here' do
+  describe "#failed" do
+    it "should not be implemented here" do
       expect { inspector.failed(paths) }.to raise_error(abstract_error)
     end
   end
 
-  describe '#reload' do
-    it 'should not be emplemented here' do
+  describe "#reload" do
+    it "should not be implemented here" do
       expect { inspector.reload }.to raise_error(abstract_error)
     end
   end


### PR DESCRIPTION
I think current watchdir option doesn't work as it should (please correct me if I'm missing something).

My recent project was consisted of many different modules each of them having it's own tests suite.
I've tried to use watchdir option but it didn't work as I expected.

I've created sample project and described steps to reproduce the issue and fix for the issue with my forks (https://github.com/lesniakania/guard and https://github.com/lesniakania/guard-rspec):

https://github.com/lesniakania/multiple-modules-with-guard

These changes depends on changes I've made in guard repo.
