### PR TITLE
Set the guard dependency to be less than version 2.9 to fix the travis build

### DIFF
--- a/gemfiles/Gemfile.rspec-2.14
+++ b/gemfiles/Gemfile.rspec-2.14
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gemspec path: '../'
 
 gem 'rspec', '~> 2.14'
+gem 'guard',  '< 2.9'
 
 group :test do
   gem 'coveralls', require: false

--- a/gemfiles/Gemfile.rspec-2.99
+++ b/gemfiles/Gemfile.rspec-2.99
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gemspec path: '../'
 
 gem 'rspec', '~> 2.99'
+gem 'guard', '< 2.9'
 
 group :test do
   gem 'coveralls', require: false

--- a/gemfiles/Gemfile.rspec-3.0
+++ b/gemfiles/Gemfile.rspec-3.0
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gemspec path: '../'
 
 gem 'rspec', '~> 3.0.0'
+gem 'guard',  '< 2.9'
 
 group :test do
   gem 'coveralls', require: false


### PR DESCRIPTION
This should fix `rake:test:all_versions` both locally and on travis and fix #296 . 

This is a temporary fix - ideally the specs should work with the latest version of guard, but I figured this is a good start!
