### PR TITLE
Fix execution_result to fit RSpec3

### DIFF
--- a/lib/guard/rspec_formatter.rb
+++ b/lib/guard/rspec_formatter.rb
@@ -92,7 +92,11 @@ module Guard
 
     def _failed_paths
       failed = examples.select do |e|
-        e.execution_result[:status].to_s == "failed"
+        if self.class.rspec_3?
+          e.execution_result.status.to_s == "failed"
+        else
+          e.execution_result[:status].to_s == "failed"
+        end
       end
 
       klass = self.class

--- a/spec/lib/guard/rspec_formatter_spec.rb
+++ b/spec/lib/guard/rspec_formatter_spec.rb
@@ -54,6 +54,10 @@ RSpec.describe Guard::RSpecFormatter do
         )
       end
 
+      before do
+        allow(formatter.class).to receive(:rspec_3?).and_return(false)
+      end
+
       def expected_output(spec_filename)
         /^3 examples, 1 failures in 123\.0 seconds\n#{spec_filename}\n$/
       end
@@ -79,6 +83,13 @@ RSpec.describe Guard::RSpecFormatter do
         end
         before do
           allow(formatter.class).to receive(:rspec_3?).and_return(true)
+        end
+
+        let(:failed_example) do
+          double(
+            execution_result: double(status: "failed"),
+            metadata: { location: spec_filename }
+          )
         end
 
         it "writes summary line and failed location" do


### PR DESCRIPTION
In RSpec 3, execution_result is migrated from a hash to a first-class object. https://github.com/rspec/rspec-core/blob/master/Changelog.md
