### PR TITLE
Enable to open rspec result from emacs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ failed_mode: :focus    # What to do with failed specs
 all_after_pass: true   # Run all specs after changed specs pass, default: false
 all_on_start: true     # Run all the specs at startup, default: false
 launchy: nil           # Pass a path to an rspec results file, e.g. ./tmp/spec_results.html
+emacs: nil             # Pass a path to an rspec results file, e.g. ./tmp/spec_results.txt
 notification: false    # Display notification after the specs are done running, default: true
 run_all: { cmd: 'custom rspec command', message: 'custom message' } # Custom options to use when running all specs
 title: 'My project'    # Display a custom title for the notification, default: 'RSpec results'
@@ -104,6 +105,17 @@ Configure your Guardfile with the launchy option:
 
 ``` ruby
 guard :rspec, cmd: 'rspec -f html -o ./tmp/spec_results.html', launchy: './tmp/spec_results.html' do
+  # ...
+end
+```
+
+### Using Emacs to view rspec results
+
+guard-rspec can be configured to launch a results file in lieu of outputing rspec results to the terminal.
+Configure your Guardfile with the emacs option:
+
+``` ruby
+guard :rspec, cmd: 'rspec -o ./spec_results.txt', emacs: './spec_results.txt' do
   # ...
 end
 ```

--- a/lib/guard/rspec/options.rb
+++ b/lib/guard/rspec/options.rb
@@ -10,6 +10,7 @@ module Guard
         cmd:             nil,
         cmd_additional_args: nil,
         launchy:         nil,
+        emacs:           nil,
         notification:    true,
         title:           "RSpec results"
       }

--- a/spec/lib/guard/rspec/runner_spec.rb
+++ b/spec/lib/guard/rspec/runner_spec.rb
@@ -210,6 +210,20 @@ RSpec.describe Guard::RSpec::Runner do
 
         runner.run(paths)
       end
+      context "with emacs option" do
+        let(:options) { { cmd: "rspec", emacs: "emacs_path" } }
+
+        before do
+          allow(Pathname).to receive(:new).
+            with("emacs_path") { double(exist?: true) }
+        end
+
+        it "opens emacs" do
+          expect(IO).to receive(:popen).
+            with(array_including("emacsclient", "--eval"))
+          runner.run(paths)
+        end
+      end
     end
 
     it "notifies success" do


### PR DESCRIPTION
This PR add feature to open rspec result from emacs. And this feature is enabled only when test fail.
![guard-emacs](https://cloud.githubusercontent.com/assets/235329/5439721/761e72e6-84c5-11e4-8786-677d6c304d0e.gif)
