### PR TITLE
fix crash by returning after notify_failure

### DIFF
--- a/lib/guard/rspec/runner.rb
+++ b/lib/guard/rspec/runner.rb
@@ -100,6 +100,7 @@ module Guard
         summary, failed_paths = _command_output
         unless summary && failed_paths
           notifier.notify_failure
+          return
         end
 
         inspector.failed(failed_paths)

--- a/lib/guard/rspec_formatter.rb
+++ b/lib/guard/rspec_formatter.rb
@@ -2,6 +2,7 @@
 # other classes in this project!
 
 require "pathname"
+require "fileutils"
 
 require "rspec"
 require "rspec/core/formatters/base_formatter"


### PR DESCRIPTION
Guard crashes on my machine unless I insert this return statement.  Dunno if it's the right fix.

What's funny is that the bug seems to be introduced as a result of RuboCop?  https://github.com/guard/guard-rspec/commit/846ca4854ed290173ecd56d8a50ce255e7d9a598

Here's the crash:

```
07:43:32 - ERROR - Guard::RSpec failed to achieve its <run_all>, exception was:
> [#CD64AA63CA3A] NoMethodError: undefined method `match' for nil:NilClass
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-rspec-4.5.0/lib/guard/rspec/notifier.rb:32:in `_parse_summary'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-rspec-4.5.0/lib/guard/rspec/notifier.rb:12:in `notify'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-rspec-4.5.0/lib/guard/rspec/runner.rb:107:in `_process_run_result'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-rspec-4.5.0/lib/guard/rspec/runner.rb:45:in `block in _run'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-rspec-4.5.0/lib/guard/rspec/runner.rb:44:in `tap'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-rspec-4.5.0/lib/guard/rspec/runner.rb:44:in `_run'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-rspec-4.5.0/lib/guard/rspec/runner.rb:24:in `run_all'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-rspec-4.5.0/lib/guard/rspec.rb:33:in `block in run_all'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-rspec-4.5.0/lib/guard/rspec.rb:48:in `_throw_if_failed'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-rspec-4.5.0/lib/guard/rspec.rb:33:in `run_all'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-2.11.1/lib/guard/runner.rb:82:in `block in _supervise'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-2.11.1/lib/guard/runner.rb:79:in `catch'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-2.11.1/lib/guard/runner.rb:79:in `_supervise'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-2.11.1/lib/guard/runner.rb:22:in `block (3 levels) in run'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-2.11.1/lib/guard/runner.rb:119:in `block (2 levels) in _run_group_plugins'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-2.11.1/lib/guard/runner.rb:117:in `each'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-2.11.1/lib/guard/runner.rb:117:in `block in _run_group_plugins'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-2.11.1/lib/guard/runner.rb:116:in `catch'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-2.11.1/lib/guard/runner.rb:116:in `_run_group_plugins'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-2.11.1/lib/guard/runner.rb:21:in `block (2 levels) in run'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-2.11.1/lib/guard/runner.rb:20:in `each'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-2.11.1/lib/guard/runner.rb:20:in `block in run'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/lumberjack-1.0.9/lib/lumberjack.rb:32:in `unit_of_work'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-2.11.1/lib/guard/runner.rb:18:in `run'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-2.11.1/lib/guard/commander.rb:82:in `run_all'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-2.11.1/lib/guard/internals/queue.rb:42:in `block in _run_actions'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-2.11.1/lib/guard/internals/queue.rb:37:in `each'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-2.11.1/lib/guard/internals/queue.rb:37:in `_run_actions'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-2.11.1/lib/guard/internals/queue.rb:21:in `process'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-2.11.1/lib/guard/commander.rb:43:in `start'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-2.11.1/lib/guard/cli/environments/valid.rb:16:in `start_guard'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-2.11.1/lib/guard/cli.rb:113:in `start'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-2.11.1/lib/guard/aruba_adapter.rb:32:in `execute'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-2.11.1/lib/guard/aruba_adapter.rb:19:in `execute!'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/gems/guard-2.11.1/bin/guard:11:in `<top (required)>'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/bin/guard:23:in `load'
> [#CD64AA63CA3A] /Users/bronson/.gem/ruby/2.2.0/bin/guard:23:in `<main>'
07:43:32 - INFO - Guard::RSpec has just been fired
```