### PR TITLE
find spec/foo_spec.rb when no spec/lib/foo_spec.rb

### DIFF
--- a/lib/guard/rspec/dsl.rb
+++ b/lib/guard/rspec/dsl.rb
@@ -13,10 +13,22 @@ module Guard
         @dsl.send(:watch, expr) { |m| rspec.spec.(m[1]) }
       end
 
+      def self.detect_spec_file_for(rspec, file)
+        # TODO: when spec not found ... run specs in topmost found path?
+        # Or show warning?
+
+        path = "#{rspec.spec_dir}/#{file}_spec.rb"
+        return path unless file.start_with?("lib/")
+        return path if Dir.exist?("#{rspec.spec_dir}/lib")
+
+        without_lib = file.sub(/^lib\//, "")
+        "#{rspec.spec_dir}/#{without_lib}_spec.rb"
+      end
+
       def rspec
         @rspec ||= OpenStruct.new(to_s: "spec").tap do |rspec|
           rspec.spec_dir = "spec"
-          rspec.spec = ->(m) { "#{rspec.spec_dir}/#{m}_spec.rb" }
+          rspec.spec = ->(m) { Dsl.detect_spec_file_for(rspec, m) }
           rspec.spec_helper = "#{rspec.spec_dir}/spec_helper.rb"
           rspec.spec_files = %r{^#{rspec.spec_dir}/.+_spec\.rb$}
           rspec.spec_support = %r{^#{rspec.spec_dir}/support/(.+)\.rb$}

--- a/spec/lib/guard/rspec/template_spec.rb
+++ b/spec/lib/guard/rspec/template_spec.rb
@@ -14,8 +14,24 @@ RSpec.describe "Guard::RSpec" do
       expect(subject.changed("spec/spec_helper.rb")).to eq(%w(spec))
     end
 
-    it "matches Ruby files by default" do
-      expect(subject.changed("lib/foo.rb")).to eq(%w(spec/lib/foo_spec.rb))
+    describe "mapping files to specs" do
+      before do
+        allow(Dir).to receive(:exist?).with("spec/lib").and_return(has_spec_lib)
+      end
+
+      context "when spec/lib exists" do
+        let(:has_spec_lib) { true }
+        it "matches Ruby files with files in spec/lib" do
+          expect(subject.changed("lib/foo.rb")).to eq(%w(spec/lib/foo_spec.rb))
+        end
+      end
+
+      context "when spec/lib does not exist" do
+        let(:has_spec_lib) { false }
+        it "matches Ruby files with files in spec/lib" do
+          expect(subject.changed("lib/foo.rb")).to eq(%w(spec/foo_spec.rb))
+        end
+      end
     end
 
     it "matches Rails files by default" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -107,7 +107,7 @@ RSpec.configure do |config|
       end
     end
 
-    %w(mkdir).each do |meth|
+    %w(mkdir mkdir_p).each do |meth|
       allow(FileUtils).to receive(meth.to_sym) do |*args|
         abort "stub me: FileUtils.#{meth}(#{args.map(&:inspect) * ','})!"
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -97,6 +97,12 @@ RSpec.configure do |config|
   config.raise_errors_for_deprecations!
 
   config.before do
+    %w(exist?).each do |meth|
+      allow(Dir).to receive(meth.to_sym) do |*args|
+        abort "stub me: Dir.#{meth}(#{args.map(&:inspect) * ','})!"
+      end
+    end
+
     allow(Dir).to receive(:[]) do |*args|
       abort "stub me: Dir[#{args.first}]!"
     end


### PR DESCRIPTION
Since tools like `bundle gem` create the structure without lib,
Guard::RSpec should fall back to looking for files there too (fixes #322)