### PR TITLE
use new accessor for example group metadata

### DIFF
--- a/lib/guard/rspec_formatter.rb
+++ b/lib/guard/rspec_formatter.rb
@@ -33,7 +33,7 @@ module Guard
       location = metadata[:location]
 
       until spec_path?(location)
-        metadata = metadata[:example_group]
+        metadata = metadata[:parent_example_group]
 
         unless metadata
           STDERR.puts "no spec file found for #{root_metadata[:location]}"


### PR DESCRIPTION
Ran into a deprecation issue when one of my specs (run via `guard :rspec, cmd: 'bundle exec rspec'`) throws an exception:

```
/Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/rspec-core-3.3.1/lib/rspec/core/formatters/deprecation_formatter.rb:186:in `puts': The `:example_group` key in an example group's metadata hash is deprecated. Use the example group's hash directly for the computed keys and `:parent_example_group` to access the parent example group metadata instead. Called from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/guard-rspec-4.5.2/lib/guard/rspec_formatter.rb:36:in `yield'. (RSpec::Core::DeprecationError)
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/rspec-core-3.3.1/lib/rspec/core/formatters/deprecation_formatter.rb:125:in `print_deprecation_message'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/rspec-core-3.3.1/lib/rspec/core/formatters/deprecation_formatter.rb:36:in `deprecation'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/rspec-core-3.3.1/lib/rspec/core/reporter.rb:184:in `block in notify'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/rspec-core-3.3.1/lib/rspec/core/reporter.rb:183:in `each'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/rspec-core-3.3.1/lib/rspec/core/reporter.rb:183:in `notify'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/rspec-core-3.3.1/lib/rspec/core/reporter.rb:146:in `deprecation'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/rspec-core-3.3.1/lib/rspec/core/warnings.rb:11:in `deprecate'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/rspec-core-3.3.1/lib/rspec/core/metadata.rb:274:in `block in backwards_compatibility_default_proc'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/guard-rspec-4.5.2/lib/guard/rspec_formatter.rb:36:in `yield'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/guard-rspec-4.5.2/lib/guard/rspec_formatter.rb:36:in `extract_spec_location'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/guard-rspec-4.5.2/lib/guard/rspec_formatter.rb:93:in `block in _failed_paths'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/guard-rspec-4.5.2/lib/guard/rspec_formatter.rb:93:in `map'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/guard-rspec-4.5.2/lib/guard/rspec_formatter.rb:93:in `_failed_paths'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/guard-rspec-4.5.2/lib/guard/rspec_formatter.rb:80:in `block in write_summary'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/guard-rspec-4.5.2/lib/guard/rspec_formatter.rb:87:in `open'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/guard-rspec-4.5.2/lib/guard/rspec_formatter.rb:87:in `_write'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/guard-rspec-4.5.2/lib/guard/rspec_formatter.rb:78:in `write_summary'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/guard-rspec-4.5.2/lib/guard/rspec_formatter.rb:66:in `dump_summary'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/rspec-core-3.3.1/lib/rspec/core/reporter.rb:184:in `block in notify'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/rspec-core-3.3.1/lib/rspec/core/reporter.rb:183:in `each'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/rspec-core-3.3.1/lib/rspec/core/reporter.rb:183:in `notify'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/rspec-core-3.3.1/lib/rspec/core/reporter.rb:162:in `block in finish'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/rspec-core-3.3.1/lib/rspec/core/reporter.rb:170:in `close_after'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/rspec-core-3.3.1/lib/rspec/core/reporter.rb:151:in `finish'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/rspec-core-3.3.1/lib/rspec/core/reporter.rb:79:in `report'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/rspec-core-3.3.1/lib/rspec/core/runner.rb:113:in `run_specs'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/rspec-core-3.3.1/lib/rspec/core/runner.rb:89:in `run'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/rspec-core-3.3.1/lib/rspec/core/runner.rb:73:in `run'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/rspec-core-3.3.1/lib/rspec/core/runner.rb:41:in `invoke'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/gems/rspec-core-3.3.1/exe/rspec:4:in `<top (required)>'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/bin/rspec:23:in `load'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/bin/rspec:23:in `<main>'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/bin/ruby_executable_hooks:15:in `eval'
	from /Users/aidanfeldman/.rvm/gems/ruby-2.1.3/bin/ruby_executable_hooks:15:in `<main>'
```

More info: https://github.com/rspec/rspec-rails/issues/1035.