### PR TITLE
Avoid RSpec 3 deprecation warning [close #327]

### DIFF
--- a/lib/guard/rspec_formatter.rb
+++ b/lib/guard/rspec_formatter.rb
@@ -33,10 +33,10 @@ module Guard
       location = metadata[:location]
 
       until spec_path?(location)
-        metadata = metadata[:example_group]
+        metadata = metadata[:parent_example_group] || metadata[:example_group]
 
         unless metadata
-          STDERR.puts "no spec file found for #{root_metadata[:location]}"
+          STDERR.puts "no spec file location in #{root_metadata.inspect}"
           return root_metadata[:location]
         end
 

--- a/spec/lib/guard/rspec_formatter_spec.rb
+++ b/spec/lib/guard/rspec_formatter_spec.rb
@@ -145,10 +145,40 @@ RSpec.describe Guard::RSpecFormatter do
         }
 
         expect(STDERR).to receive(:puts).
-          with("no spec file found for #{metadata[:location]}") {}
+          with("no spec file location in #{metadata.inspect}")
 
         expect(described_class.extract_spec_location(metadata)).
           to eq metadata[:location]
+      end
+    end
+
+    context "when a shared examples are nested" do
+      it "should return location of the root spec" do
+        metadata = {
+          location: "./spec/support/breadcrumbs.rb:75",
+          example_group: {
+            example_group: {
+              location: "./spec/requests/breadcrumbs_spec.rb:218"
+            }
+          }
+        }
+
+        expect(described_class.extract_spec_location(metadata)).
+          to eq "./spec/requests/breadcrumbs_spec.rb"
+      end
+    end
+
+    context "when RSpec 3.0 metadata is present" do
+      it "should return location of the root spec" do
+        metadata = {
+          location: "./spec/support/breadcrumbs.rb:75",
+          parent_example_group: {
+            location: "./spec/requests/breadcrumbs_spec.rb:218"
+          }
+        }
+
+        expect(described_class.extract_spec_location(metadata)).
+          to eq "./spec/requests/breadcrumbs_spec.rb"
       end
     end
 


### PR DESCRIPTION
RSpec 3 deprecates :example_group metadata key - this avoids the warning/error.

Also, metadata failures should are more detailed from now on.

[closes #327]