### PR TITLE
rework Zeus env workaround [fix #326]

### DIFF
--- a/lib/guard/rspec/runner.rb
+++ b/lib/guard/rspec/runner.rb
@@ -1,3 +1,5 @@
+require "guard/rspec_defaults"
+
 require "guard/rspec/inspectors/factory"
 require "guard/rspec/command"
 require "guard/rspec/notifier"
@@ -80,7 +82,7 @@ module Guard
       end
 
       def _results_file(results_file, chdir)
-        results_file ||= TEMPORARY_FILE_PATH
+        results_file ||= RSpecDefaults::TEMPORARY_FILE_PATH
         return results_file unless Pathname(results_file).relative?
         chdir ? File.join(chdir, results_file) : results_file
       end

--- a/lib/guard/rspec_defaults.rb
+++ b/lib/guard/rspec_defaults.rb
@@ -1,0 +1,5 @@
+module Guard
+  class RSpecDefaults
+    TEMPORARY_FILE_PATH = "tmp/rspec_guard_result"
+  end
+end

--- a/lib/guard/rspec_formatter.rb
+++ b/lib/guard/rspec_formatter.rb
@@ -7,8 +7,16 @@ require "fileutils"
 require "rspec"
 require "rspec/core/formatters/base_formatter"
 
+require "guard/rspec_defaults"
+
 module Guard
   class RSpecFormatter < ::RSpec::Core::Formatters::BaseFormatter
+    WIKI_ENV_WARN_URL =
+      "https://github.com/guard/guard-rspec/wiki/Warning:-no-environment"
+
+    NO_ENV_WARNING_MSG = "no environment passed - see #{WIKI_ENV_WARN_URL}"
+    NO_RESULTS_VALUE_MSG = ":results_file value unknown (using defaults)"
+
     def self.rspec_3?
       ::RSpec::Core::Version::STRING.split(".").first == "3"
     end
@@ -110,7 +118,12 @@ module Guard
 
     def _results_file
       path = ENV["GUARD_RSPEC_RESULTS_FILE"]
-      fail "Fatal: No output file given for Guard::RSpec formatter!" unless path
+      if path.nil?
+        STDERR.puts "Guard::RSpec: Warning: #{NO_ENV_WARNING_MSG}\n" \
+          "Guard::RSpec: Warning: #{NO_RESULTS_VALUE_MSG}"
+        path = RSpecDefaults::TEMPORARY_FILE_PATH
+      end
+
       File.expand_path(path)
     end
   end

--- a/spec/lib/guard/rspec_formatter_spec.rb
+++ b/spec/lib/guard/rspec_formatter_spec.rb
@@ -86,6 +86,35 @@ RSpec.describe Guard::RSpecFormatter do
           end.to raise_error(TypeError, "foo")
         end
       end
+
+      context "when no env is passed" do
+        let(:file) { File.join(Dir.pwd, "tmp/rspec_guard_result") }
+
+        before do
+          ENV["GUARD_RSPEC_RESULTS_FILE"] = nil
+
+          allow(FileUtils).to receive(:mkdir_p).
+            with(File.dirname(file)) {}
+
+          allow(File).to receive(:open).
+            with(file, "w") do |_, _, &block|
+            block.call writer
+          end
+        end
+
+        it "warns" do
+          expect(STDERR).to receive(:puts).with(/no environment/)
+          formatter.dump_summary(*example_dump_summary_args)
+        end
+
+        it "uses default file" do
+          expect(File).to receive(:open).
+            with(file, "w") do |_, _, &block|
+            block.call writer
+          end
+          formatter.dump_summary(*example_dump_summary_args)
+        end
+      end
     end
 
     context "with failures" do


### PR DESCRIPTION
Zeus doesn't pass environment variables, so Guard::RSpec can't
pass it's formatter file to the RSpec formatter through the environment.

This shows a warning (with url for info) and uses default results file instead.