### PR TITLE
Fix return value of the runner

### DIFF
--- a/spec/lib/guard/rspec/runner_spec.rb
+++ b/spec/lib/guard/rspec/runner_spec.rb
@@ -137,6 +137,20 @@ RSpec.describe Guard::RSpec::Runner do
         expect(notifier).to have_received(:notify_failure)
       end
     end
+
+    describe "return value" do
+      subject { runner.run_all }
+
+      it { is_expected.to be true }
+
+      context "when process is not all green" do
+        before do
+          allow(process).to receive(:all_green?).and_return(false)
+        end
+
+        it { is_expected.to be false }
+      end
+    end
   end
 
   describe "#run" do
@@ -283,6 +297,36 @@ RSpec.describe Guard::RSpec::Runner do
 
       expect(notifier).to receive(:notify_failure)
       runner.run(paths)
+    end
+
+    describe "return value" do
+      subject { runner.run(paths) }
+
+      it { is_expected.to be true }
+
+      context "with all_after_pass option" do
+        let(:options) do
+          { cmd: "rspec", all_after_pass: true, run_all: {}, spec_paths: paths }
+        end
+
+        it { is_expected.to be true }
+
+        describe "when all tests fail" do
+          before do
+            allow(process).to receive(:all_green?).and_return(true, false)
+          end
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context "when process is not all green" do
+        before do
+          allow(process).to receive(:all_green?).and_return(false)
+        end
+
+        it { is_expected.to be false }
+      end
     end
   end
 end


### PR DESCRIPTION
The refactoring in d4591fc broke throwing of `:task_has_failed` because the runner was changed to always return `true` from `#run` and `#run_all`. The invalid return value caused `:task_has_failed` to never be thrown, thus breaking the behavior of a group's `:halt_on_fail` option.