### PR TITLE
detect unsupported RSpec spec pattern

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ matrix:
   allow_failures:
     - rvm: rbx
     - rvm: jruby-head
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 bundler_args: --without tool
 rvm:
   - 2.2.2
-  - jruby-19mode
+  - jruby-head
   - rbx
 gemfile:
   - gemfiles/Gemfile.rspec-2.14
@@ -10,6 +10,5 @@ gemfile:
   - gemfiles/Gemfile.rspec-3.3
 matrix:
   allow_failures:
-    - rvm: jruby-19mode
     - rvm: rbx
-    - rvm: 1.9.3
+    - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,11 @@ bundler_args: --without tool
 rvm:
   - 2.2.2
   - jruby-head
-  - rbx
 gemfile:
   - gemfiles/Gemfile.rspec-2.14
   - gemfiles/Gemfile.rspec-2.99
   - gemfiles/Gemfile.rspec-3.3
 matrix:
   allow_failures:
-    - rvm: rbx
     - rvm: jruby-head
 sudo: false

--- a/spec/lib/guard/rspec_formatter_spec.rb
+++ b/spec/lib/guard/rspec_formatter_spec.rb
@@ -100,6 +100,8 @@ RSpec.describe Guard::RSpecFormatter do
             with(file, "w") do |_, _, &block|
             block.call writer
           end
+
+          allow(STDERR).to receive(:puts).with(/no environment/)
         end
 
         it "warns" do

--- a/spec/lib/guard/rspec_formatter_spec.rb
+++ b/spec/lib/guard/rspec_formatter_spec.rb
@@ -228,5 +228,29 @@ RSpec.describe Guard::RSpecFormatter do
         )
       end
     end
+
+    context "when RSpec 3.0 uses ext globs" do
+      before do
+        allow(::RSpec.configuration).to receive(:pattern).
+          and_return("**{,/*/**}/*_spec.rb")
+      end
+
+      context "when Ruby does not support ext glob matcher" do
+        before do
+          allow(File).to receive(:const_defined?).with(:FNM_EXTGLOB) { false }
+        end
+
+        let(:metadata) { { location: "./spec/foo_spec.rb:75" } }
+
+        it "fails" do
+          expect do
+            described_class.extract_spec_location(metadata)
+          end.to raise_error(
+            described_class::Error::UnsupportedPattern,
+            "Your RSpec.configuration.pattern uses characters unsupported "\
+            "by your Ruby version (File::FNM_EXTGLOB is undefined)")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Show an error so that users either simplify the RSpec glob pattern
(RSpec.configuration.pattern) or upgrade to a Ruby version supporting
FNM_EXTGLOB (fixes #338)