### PR TITLE
Fixes guard-process collision

### DIFF
--- a/lib/guard/rspec/rspec_process.rb
+++ b/lib/guard/rspec/rspec_process.rb
@@ -36,7 +36,7 @@ module Guard
       def _really_run
         env = { "GUARD_RSPEC_RESULTS_FILE" => formatter_tmp_file }
         pid = Kernel.spawn(env, command) # use spawn to stub in JRuby
-        result = Process.wait2(pid)
+        result = ::Process.wait2(pid)
         result.last.exitstatus
       rescue Errno::ENOENT => ex
         fail Failure, "Failed: #{command.inspect} (#{ex})"


### PR DESCRIPTION
When using guard-rspec and guard-process Guard::Process.wait2 method is called, which doesn't exists, the expected behaviour is to call Process.wait2 from ruby's stdlib, this happens due to a conflict in resolving Process constant which is evaluated against Guard.