### PR TITLE
Fix deprecation message for focus_on_failed.

### DIFF
--- a/lib/guard/rspec/deprecator.rb
+++ b/lib/guard/rspec/deprecator.rb
@@ -71,8 +71,8 @@ module Guard
         return unless options.key?(:focus_on_failed)
         _deprecated(
           "The :focus_on_failed option is deprecated." +
-          " Focus mode is the default and can be changed using new" +
-          " :failed_mode option." +
+          " Please set new :failed_mode option value to" +
+          " :focus instead." +
           " https://github.com/guard/guard-rspec#list-of-available-options")
       end
 

--- a/spec/lib/guard/rspec/deprecator_spec.rb
+++ b/spec/lib/guard/rspec/deprecator_spec.rb
@@ -84,8 +84,8 @@ RSpec.describe Guard::RSpec::Deprecator do
         expect(Guard::Compat::UI).to receive(:warning).with(
           "Guard::RSpec DEPRECATION WARNING:" +
           " The :focus_on_failed option is deprecated." +
-          " Focus mode is the default and can be changed using new" +
-          " :failed_mode option." +
+          " Please set new :failed_mode option value to" +
+          " :focus instead." +
           " https://github.com/guard/guard-rspec#list-of-available-options")
         deprecator.warns_about_deprecated_options
       end


### PR DESCRIPTION
The default for failed_mode is :none, not :focus.

See 802edda29844df05ad6d7fe0f6304cc1ff855d9a