### PR TITLE
Added missing `=` to `||=` assignment operator.

### DIFF
--- a/lib/guard/rspec/dsl.rb
+++ b/lib/guard/rspec/dsl.rb
@@ -37,7 +37,7 @@ module Guard
 
       def ruby
         # Ruby apps
-        @ruby || OpenStruct.new.tap do |ruby|
+        @ruby ||= OpenStruct.new.tap do |ruby|
           ruby.lib_files = %r{^(lib/.+)\.rb$}
         end
       end


### PR DESCRIPTION
Just noticed that the `rspec` and `rails` method used the `||=` operator and the `ruby` method didn't.