### PR TITLE
Homepage URL

### DIFF
--- a/guard-rspec.gemspec
+++ b/guard-rspec.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.description = "Guard::RSpec automatically run your specs" +
     " (much like autotest)."
 
-  s.homepage    = "https://rubygems.org/gems/guard-rspec"
+  s.homepage    = "https://github.com/guard/guard-rspec"
   s.license     = "MIT"
 
   s.files        = `git ls-files`.split($INPUT_RECORD_SEPARATOR)


### PR DESCRIPTION
When on the rubygems.org page for guard-rspec, clicking the homepage link would redirect to the same page, thus serving no purpose.

I propose to change the url to the github page, which has all the information that is required to use the gem.