### PR TITLE
Fixes 'NameError: uninitialized constant Guard::Guard::Compat'.

### DIFF
--- a/guard-rspec.gemspec
+++ b/guard-rspec.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.email       = "thibaud@thibaud.gg"
   s.summary     = "Guard gem for RSpec"
   s.description = "Guard::RSpec automatically run your specs" +
-    " (much like autotest)."
+                  " (much like autotest)."
 
   s.homepage    = "https://github.com/guard/guard-rspec"
   s.license     = "MIT"

--- a/lib/guard/rspec.rb
+++ b/lib/guard/rspec.rb
@@ -25,7 +25,7 @@ module Guard
     end
 
     def start
-      Guard::Compat::UI.info "Guard::RSpec is running"
+      Compat::UI.info "Guard::RSpec is running"
       run_all if options[:all_on_start]
     end
 

--- a/lib/guard/rspec/options.rb
+++ b/lib/guard/rspec/options.rb
@@ -5,7 +5,7 @@ module Guard
         all_on_start:    false,
         all_after_pass:  false,
         run_all:         { message: "Running all specs" },
-        failed_mode:     :none,  # :keep and :focus are other posibilities
+        failed_mode:     :none, # :keep and :focus are other posibilities
         spec_paths:      %w(spec),
         cmd:             nil,
         cmd_additional_args: nil,

--- a/spec/lib/guard/rspec/notifier_spec.rb
+++ b/spec/lib/guard/rspec/notifier_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Guard::RSpec::Notifier do
   let(:options) { { notification: true, title: "RSpec results" } }
   let(:notifier) { Guard::RSpec::Notifier.new(options) }
 
-  def expect_notification(title = "RSpec results", message, image, priority)
+  def expect_notification(message, image, priority, title = "RSpec results")
     expect(Guard::Compat::UI).to receive(:notify).
       with(message,  title: title, image: image, priority: priority)
   end
@@ -21,7 +21,7 @@ RSpec.describe Guard::RSpec::Notifier do
       let(:options) { { notification: true, title: "Failure title" } }
 
       it "notifies with the title" do
-        expect_notification("Failure title", "Failed", :failed, 2)
+        expect_notification("Failed", :failed, 2, "Failure title")
         notifier.notify_failure
       end
     end
@@ -64,7 +64,7 @@ RSpec.describe Guard::RSpec::Notifier do
       let(:options) { { notification: true, title: "Custom title" } }
 
       it "notifies with the title" do
-        expect_notification("Custom title", "This is summary", :success, -2)
+        expect_notification("This is summary", :success, -2, "Custom title")
         notifier.notify("This is summary")
       end
     end

--- a/spec/lib/guard/rspec_formatter_spec.rb
+++ b/spec/lib/guard/rspec_formatter_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe Guard::RSpecFormatter do
 
       around do |example|
         env_var = "GUARD_RSPEC_RESULTS_FILE"
-        old, ENV[env_var] = ENV[env_var], "foobar.txt"
+        old = ENV[env_var]
+        ENV[env_var] = "foobar.txt"
         example.run
         ENV[env_var] = old
       end


### PR DESCRIPTION
In a side project, using the following gem versions:

.gemspec:
```
...
# development dependencies.
gem.add_development_dependency('rspec', '~> 3.4.0')
gem.add_development_dependency('simplecov', '~> 0.7.0')
gem.add_development_dependency('guard', '~> 2.8.0')
gem.add_development_dependency('guard-rspec', '~> 4.6.4')
gem.add_development_dependency('rubocop', '~> 0.35.1')
gem.add_development_dependency('guard-rubocop', '~> 1.2.0')
gem.add_development_dependency('metric_fu', '~> 4.2.0')
gem.add_development_dependency('guard-reek', '~> 0.0.4')
gem.add_development_dependency('rake', '~> 10.4.2')
gem.add_development_dependency('yard', '~> 0.8.7')
gem.add_development_dependency('redcarpet', '~> 2.3.0')
```

Guardfile:
```
# vim: ft=ruby
# More info at https://github.com/guard/guard#readme
#
# More info also at https://github.com/guard/guard-rspec -- this one in
# particular details configuration options such as whether to run all tests
# after a failing test starts passing

guard :rspec, cmd: 'bundle exec rspec', cli: '--tag ~slow' do
  watch(%r{^spec/.+_spec\.rb})
  watch(%r{/^lib/(.+)\.rb$}) do |match|
    %w(unit integration acceptance).map do |kind|
      "spec/#{kind}/lib/#{match[1]}_spec.rb"
    end
  end
  watch('spec/spec_helper.rb')  { 'spec' }
  watch(%r{^spec/(fixtures|resources)(/|.rb)}) { 'spec' }
end

guard :rubocop, all_on_start: false do
  watch('Guardfile')
  watch(%r{/.+\.rb$})
  watch(%r{(?:.+\/)?\.rubocop\.yml$}) { |m| File.dirname(m[0]) }
end

guard :reek do
  watch(%r{^lib/(.+)\.rb$})
end
```

Running `bundle exec guard --debug`
```
04:28:10 - INFO - Guard is using TerminalTitle to send notifications.
04:28:10 - DEBUG - Command execution: hash stty
04:28:10 - DEBUG - Guard starts all plugins
04:28:10 - DEBUG - Hook :start_begin executed for Guard::RSpec
04:28:10 - ERROR - Guard::RSpec failed to achieve its <start>, exception was:
> [#BCDB8011A582] NameError: uninitialized constant Guard::Guard::Compat
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/guard-rspec-4.6.4/lib/guard/rspec.rb:28:in `start'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/guard-2.8.2/lib/guard/runner.rb:77:in `block in _supervise'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/guard-2.8.2/lib/guard/runner.rb:74:in `catch'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/guard-2.8.2/lib/guard/runner.rb:74:in `_supervise'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/guard-2.8.2/lib/guard/runner.rb:20:in `block (2 levels) in run'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/guard-2.8.2/lib/guard/runner.rb:135:in `block (3 levels) in _scoped_plugins'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/guard-2.8.2/lib/guard/runner.rb:133:in `each'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/guard-2.8.2/lib/guard/runner.rb:133:in `block (2 levels) in _scoped_plugins'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/guard-2.8.2/lib/guard/runner.rb:132:in `catch'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/guard-2.8.2/lib/guard/runner.rb:132:in `block in _scoped_plugins'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/guard-2.8.2/lib/guard/runner.rb:129:in `each'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/guard-2.8.2/lib/guard/runner.rb:129:in `_scoped_plugins'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/guard-2.8.2/lib/guard/runner.rb:19:in `block in run'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/lumberjack-1.0.9/lib/lumberjack.rb:32:in `unit_of_work'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/guard-2.8.2/lib/guard/runner.rb:18:in `run'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/guard-2.8.2/lib/guard/commander.rb:25:in `start'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/guard-2.8.2/lib/guard/cli.rb:113:in `start'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/guard-2.8.2/lib/guard/aruba_adapter.rb:32:in `execute'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/guard-2.8.2/lib/guard/aruba_adapter.rb:19:in `execute!'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/guard-2.8.2/bin/guard:11:in `<top (required)>'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/bin/guard:23:in `load'
> [#BCDB8011A582] /Users/benson.fung/.rbenv/versions/2.2.2/bin/guard:23:in `<main>'
04:28:10 - INFO - Guard::RSpec has just been fired
```

In commit b76a839, only `lib/guard/rspec.rb` used
```
Guard::Compat::UI
```
while other files such as `lib/guard/rspec/deprecator.rb` and `lib/guard/rspec/runner.rb` used
```
Compat::UI
```

Changed `lib/guard/rspec.rb` to use same syntax.  Unsure about `lib/guard/rspec/notifier.rb`.

Also fixes rubocop violations, as running tests did not pass locally:
```
bundle exec rake test:all_versions
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.0.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 38 files
.C...........C................C....C..

Offenses:

guard-rspec.gemspec:13:5: C: Align the operands of an expression in an assignment spanning multiple lines.
    " (much like autotest)."
    ^^^^^^^^^^^^^^^^^^^^^^^^
lib/guard/rspec/options.rb:8:32: C: Unnecessary spacing detected.
        failed_mode:     :none,  # :keep and :focus are other posibilities
                               ^
spec/lib/guard/rspec/notifier_spec.rb:9:27: C: Optional arguments should appear at the end of the argument list.
  def expect_notification(title = "RSpec results", message, image, priority)
                          ^^^^^^^^^^^^^^^^^^^^^^^
spec/lib/guard/rspec_formatter_spec.rb:53:9: C: Do not use parallel assignment.
        old, ENV[env_var] = ENV[env_var], "foobar.txt"
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

38 files inspected, 4 offenses detected
```

I'm unsure of how to test the change in `lib/guard/rspec.rb`, since the test before passes even though it does not run properly - it seems like it's running in a different context of sorts.

Running rspec and rubocop locally after modification:
```
benson.fung:~/workspace/benson-fung/guard-rspec [git: fix_uninitialized_constant_Guard_Guard_Compat] $ bundle exec rake
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 26842
.............................................................................................................................no spec file location in {:location=>"failed_location_spec.rb"}
no spec file location in {:location=>"failed_location_spec.rb"}
.no spec file location in {:location=>"failed_location_spec.rb"}
.no spec file location in {:location=>"failed_location_spec.rb"}
.....................

Finished in 0.24322 seconds (files took 0.15314 seconds to load)
148 examples, 0 failures

Randomized with seed 26842

warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.0.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Running RuboCop...
Inspecting 38 files
......................................

38 files inspected, no offenses detected
```

And in my original project (modified the gem file locally to test), it works:
```
> bundle exec guard --debug
...
04:38:07 - INFO - Guard is using TerminalTitle to send notifications.
04:38:07 - DEBUG - Command execution: hash stty
04:38:07 - DEBUG - Guard starts all plugins
04:38:07 - DEBUG - Hook :start_begin executed for Guard::RSpec
Guard::RSpec is running
04:38:07 - DEBUG - Hook :start_end executed for Guard::RSpec
```