### PR TITLE
use relative require in formatter [fix #352]

### DIFF
--- a/lib/guard/rspec_formatter.rb
+++ b/lib/guard/rspec_formatter.rb
@@ -7,7 +7,7 @@ require "fileutils"
 require "rspec"
 require "rspec/core/formatters/base_formatter"
 
-require "guard/rspec_defaults"
+require_relative "rspec_defaults"
 
 module Guard
   class RSpecFormatter < ::RSpec::Core::Formatters::BaseFormatter


### PR DESCRIPTION
Avoid using 'require' since guard-rspec is not on load path