### PR TITLE
Support Rspec 3.5.0

### DIFF
--- a/guard-rspec.gemspec
+++ b/guard-rspec.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "guard", "~> 2.1"
   s.add_dependency "guard-compat", "~> 1.1"
-  s.add_dependency "rspec", ">= 2.99.0", "< 4.0"
 
   s.add_development_dependency "bundler", ">= 1.3.5", "< 2.0"
   s.add_development_dependency "rake", "~> 10.1"

--- a/lib/guard/rspec_formatter.rb
+++ b/lib/guard/rspec_formatter.rb
@@ -4,7 +4,7 @@
 require "pathname"
 require "fileutils"
 
-require "rspec"
+require "rspec/core"
 require "rspec/core/formatters/base_formatter"
 
 require_relative "rspec_defaults"


### PR DESCRIPTION
Hi,

I'm running a Rails 5 app with Rspec 3.5.0.beta1, and I have encountered that bundler is unable to resolve a valid version of Rspec:

```
Bundler could not find compatible versions for gem "rspec-core":
  In snapshot (Gemfile.lock):
    rspec-core (= 3.5.0.beta1)

  In Gemfile:
    guard-rspec (= 4.6.4) was resolved to 4.6.4, which depends on
      rspec (< 4.0, >= 2.99.0) was resolved to 2.99.0, which depends on
        rspec-core (~> 2.99.0)

    rspec-rails (= 3.5.0.beta1) was resolved to 3.5.0.beta1, which depends on
      rspec-core (= 3.5.0.beta1)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```

Maybe guard-rspec does not need to have the rspec version in the gemspec?

I also tried playing around with the version numbers, but I have been unable to find the magic syntax to make it work with rspec 3.5.0.beta1.

Warm regards,
Ignacio

