### PR TITLE
Fix spec path verification with multiple pattern

### DIFF
--- a/lib/guard/rspec_formatter.rb
+++ b/lib/guard/rspec_formatter.rb
@@ -77,7 +77,8 @@ module Guard
       path ||= ""
       path = path.sub(/:\d+\z/, "")
       path = Pathname.new(path).cleanpath.to_s
-      File.fnmatch(pattern, path, flags)
+      stripped = "{#{pattern.gsub(/\s*,\s*/, ',')}}"
+      File.fnmatch(stripped, path, flags)
     end
 
     def dump_summary(*args)

--- a/spec/lib/guard/rspec_formatter_spec.rb
+++ b/spec/lib/guard/rspec_formatter_spec.rb
@@ -255,5 +255,22 @@ RSpec.describe Guard::RSpecFormatter do
         end
       end
     end
+
+    context "when RSpec 3.0 is configured to use multiple patterns" do
+      before do
+        allow(::RSpec.configuration).to receive(:pattern).
+          and_return("**{,/*/**}/*_spec.rb,**/*.feature")
+      end
+
+      it "matches a spec file with the first pattern" do
+        expect(described_class.spec_path?("./spec/foo_spec.rb")).
+          to be_truthy
+      end
+
+      it "matches a spec file with the second pattern" do
+        expect(described_class.spec_path?("./spec/acceptance/bar.feature")).
+          to be_truthy
+      end
+    end
   end
 end


### PR DESCRIPTION
The value from `RSpec.configuration.pattern` may not satisfy a glob pattern
if multiple pattern is set (e.g. `'**{,/*/**}/*_spec.rb,**/*.feature'`).

And the formatter prints `no spec file location` warnings on STDOUT for each failed examples
because `spec_path?` method can't find the spec file location with a non-glob pattern.

This PR fixes `spec_path?` method to be able to find spec files even if a multiple pattern set.
The implementation is written referencing RSpec::Core::Configuration.

[rspec-core/configuration.rb at master · rspec/rspec-core · GitHub](https://github.com/rspec/rspec-core/blob/master/lib/rspec/core/configuration.rb#L1790)