### PR TITLE
add thorough warnings to help users report issues

### DIFF
--- a/lib/guard/rspec/runner.rb
+++ b/lib/guard/rspec/runner.rb
@@ -15,9 +15,6 @@ module Guard
         end
       end
 
-      # NOTE: must match with const in RSpecFormatter!
-      TEMPORARY_FILE_PATH ||= "tmp/rspec_guard_result".freeze
-
       attr_accessor :options, :inspector, :notifier
 
       def initialize(options = {})
@@ -85,9 +82,18 @@ module Guard
       end
 
       def _results_file(results_file, chdir)
-        results_file ||= RSpecDefaults::TEMPORARY_FILE_PATH
+        results_file ||= File.expand_path(RSpecDefaults::TEMPORARY_FILE_PATH)
         return results_file unless Pathname(results_file).relative?
-        chdir ? File.join(chdir, results_file) : results_file
+        results_file = File.join(chdir, results_file) if chdir
+        return results_file unless Pathname(results_file).relative?
+
+        unless Pathname(results_file).absolute?
+          msg = "Guard::RSpec: The results file %s is not an absolute path."\
+            " Please provide an absolute path to avoid issues."
+          Compat::UI.warning(format(msg, results_file.inspect))
+        end
+
+        File.expand_path(results_file)
       end
     end
   end

--- a/lib/guard/rspec_formatter.rb
+++ b/lib/guard/rspec_formatter.rb
@@ -9,6 +9,8 @@ require "rspec/core/formatters/base_formatter"
 
 require_relative "rspec_formatter_results_path"
 
+require "guard/ui"
+
 module Guard
   class RSpecFormatter < ::RSpec::Core::Formatters::BaseFormatter
     UNSUPPORTED_PATTERN =
@@ -115,6 +117,10 @@ module Guard
 
     def _write(&block)
       file = RSpecFormatterResultsPath.new.path
+      if Guard.const_defined?(:Compat)
+        msg = "Guard::RSpec: using results file: #{file.inspect}"
+        Guard::Compat::UI.debug(format(msg, file))
+      end
       FileUtils.mkdir_p(File.dirname(file))
       File.open(file, "w", &block)
     end


### PR DESCRIPTION
- warn about results file not being absolute
- misc diagnostic when Guard debug is active