### PR TITLE
stop using Guard::UI in formatter + isolated test

### DIFF
--- a/lib/guard/rspec_formatter.rb
+++ b/lib/guard/rspec_formatter.rb
@@ -9,8 +9,6 @@ require "rspec/core/formatters/base_formatter"
 
 require_relative "rspec_formatter_results_path"
 
-require "guard/ui"
-
 module Guard
   class RSpecFormatter < ::RSpec::Core::Formatters::BaseFormatter
     UNSUPPORTED_PATTERN =
@@ -117,9 +115,9 @@ module Guard
 
     def _write(&block)
       file = RSpecFormatterResultsPath.new.path
-      if Guard.const_defined?(:Compat)
+      if ENV['GUARD_RSPEC_DEBUGGING'] == '1'
         msg = "Guard::RSpec: using results file: #{file.inspect}"
-        Guard::Compat::UI.debug(format(msg, file))
+        STDERR.puts format(msg, file)
       end
       FileUtils.mkdir_p(File.dirname(file))
       File.open(file, "w", &block)

--- a/spec/acceptance/fixtures/succeeding_spec.rb
+++ b/spec/acceptance/fixtures/succeeding_spec.rb
@@ -1,0 +1,4 @@
+RSpec.describe "succeeding spec" do
+  it "works" do
+  end
+end

--- a/spec/acceptance/formatter_spec.rb
+++ b/spec/acceptance/formatter_spec.rb
@@ -1,0 +1,46 @@
+require 'pathname'
+require 'tempfile'
+
+require 'gem_isolator'
+
+RSpec.describe "Formatter test", type: :acceptance do
+  context "when isolated" do
+    before { allow(Kernel).to receive(:system).and_call_original }
+
+    let!(:formatter) { File.expand_path('lib/guard/rspec_formatter.rb') }
+
+    context "when a valid results file path is given" do
+      around do |example|
+        Tempfile.open('results') do |tempfile|
+          @results_file = tempfile.path
+          example.run
+        end
+      end
+
+      context "when a succeeding command is given" do
+        let!(:spec) do
+          File.expand_path('spec/acceptance/fixtures/succeeding_spec.rb')
+        end
+
+        let(:rspec_args) do
+          ['-r', formatter, '-f', 'Guard::RSpecFormatter', spec]
+        end
+
+        context "when guard is not in Gemfile" do
+          let(:gems) { [%w(rspec ~>3.4)] }
+
+          it "works" do
+            GemIsolator.isolate(gems: gems) do |env, isolation|
+              env = env.merge('GUARD_RSPEC_RESULTS_FILE' => @results_file)
+
+              # TODO: I don't know why Travis needs a full path for binaries
+              # for system() to work.
+              rspec = env['PATH'].sub(/:.*/, '/rspec')
+              expect(isolation.system(env, rspec, *rspec_args)).to eq(true)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,13 @@ end
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  config.register_ordering :global do |examples|
+    examples.partition { |ex| ex.metadata[:type] != :acceptance }.flatten(1)
+  end
+
+  # Use global for running acceptance tests last
+  config.order = :global
+
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4. It makes the `description`
     # and `failure_message` of custom matchers include text for helper methods
@@ -88,12 +95,6 @@ RSpec.configure do |config|
   # end of the spec run, to help surface which specs are running
   # particularly slow.
   # config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
 
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce


### PR DESCRIPTION
Formatter should be self-sufficient in that it shouldn't require
any gem or file other than what RSpec provides.