### PR TITLE
add configuration of Bundler env, default to new behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ run_all: { cmd: 'custom rspec command', message: 'custom message' } # Custom opt
 title: 'My project'    # Display a custom title for the notification, default: 'RSpec results'
 chdir: 'directory'     # run rspec from within a given subdirectory (useful if project has separate specs for submodules)
 results_file: 'some/path' # use the given file for storing results (instead of default relative path)
+bundler_env: :original_env # Specify which Bundler env to run the cmd under, default: :original_env
+                       # Available values:
+                       #  :clean_env - old behavior, uses Bundler environment with all bundler-related variables removed. This is deprecated in bundler 1.12.x.
+                       #  :original_env (default) - uses Bundler environment present before Bundler was activated
+                       #  :inherit - runs inside the current environment
 ```
 
 ### Using Launchy to view rspec results

--- a/lib/guard/rspec/options.rb
+++ b/lib/guard/rspec/options.rb
@@ -11,7 +11,8 @@ module Guard
         cmd_additional_args: nil,
         launchy:         nil,
         notification:    true,
-        title:           "RSpec results"
+        title:           "RSpec results",
+        bundler_env:     :original_env
       }.freeze
 
       class << self

--- a/lib/guard/rspec/runner.rb
+++ b/lib/guard/rspec/runner.rb
@@ -62,7 +62,7 @@ module Guard
         # TODO: add option to specify the file
         file = _results_file(options[:results_file], options[:chdir])
 
-        process = RSpecProcess.new(cmd, file)
+        process = RSpecProcess.new(cmd, file, options)
         results = process.results
 
         inspector.failed(results.failed_paths)

--- a/spec/lib/guard/rspec/rspec_process_spec.rb
+++ b/spec/lib/guard/rspec/rspec_process_spec.rb
@@ -111,5 +111,33 @@ RSpec.describe Guard::RSpec::RSpecProcess do
         end
       end
     end
+
+    context "with bundler_env option" do
+      it "runs without Bunder changes when :inherit" do
+        expect(Bundler).to_not receive(:with_clean_env)
+        expect(Bundler).to_not receive(:with_original_env)
+
+        described_class.new(cmd, file, bundler_env: :inherit)
+      end
+
+      it "runs on clean Bunder changes when :clean_env" do
+        expect(Bundler).to receive(:with_clean_env)
+
+        described_class.new(cmd, file, bundler_env: :clean_env)
+      end
+
+      it "runs on original Bunder changes when :original_env" do
+        expect(Bundler).to receive(:with_original_env)
+
+        described_class.new(cmd, file, bundler_env: :original_env)
+      end
+    end
+
+    context "without bundler_env option" do
+      it "runs on original Bunder" do
+        expect(Bundler).to receive(:with_original_env)
+        subject
+      end
+    end
   end
 end

--- a/spec/lib/guard/rspec/runner_spec.rb
+++ b/spec/lib/guard/rspec/runner_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe Guard::RSpec::Runner do
           let(:results_file) { File.join(Dir.pwd, "foobar.txt") }
           it "uses the given file" do
             expect(Guard::RSpec::RSpecProcess).to receive(:new).
-              with(anything, results_file).and_return(process)
+              with(anything, results_file, options).and_return(process)
             runner.run(paths)
           end
         end
@@ -227,7 +227,7 @@ RSpec.describe Guard::RSpec::Runner do
           let(:results_file) { "/foo/foobar.txt" }
           it "uses the given path" do
             expect(Guard::RSpec::RSpecProcess).to receive(:new).
-              with(anything, results_file).and_return(process)
+              with(anything, results_file, options).and_return(process)
             runner.run(paths)
           end
         end
@@ -243,7 +243,7 @@ RSpec.describe Guard::RSpec::Runner do
             it "uses a path relative to chdir" do
               expected = "/foo/bar/moduleA/foobar.txt"
               expect(Guard::RSpec::RSpecProcess).to receive(:new).
-                with(anything, expected).and_return(process)
+                with(anything, expected, options).and_return(process)
               runner.run(paths)
             end
           end
@@ -252,7 +252,7 @@ RSpec.describe Guard::RSpec::Runner do
             let(:results_file) { "/foo/foobar.txt" }
             it "uses the full given path anyway" do
               expect(Guard::RSpec::RSpecProcess).to receive(:new).
-                with(anything, results_file).and_return(process)
+                with(anything, results_file, options).and_return(process)
               runner.run(paths)
             end
           end
@@ -270,7 +270,7 @@ RSpec.describe Guard::RSpec::Runner do
             it "uses a path relative to chdir" do
               expected = File.join(Dir.pwd, "moduleA/foobar.txt")
               expect(Guard::RSpec::RSpecProcess).to receive(:new).
-                with(anything, expected).and_return(process)
+                with(anything, expected, options).and_return(process)
               runner.run(paths)
             end
 
@@ -285,7 +285,7 @@ RSpec.describe Guard::RSpec::Runner do
             let(:results_file) { "/foo/foobar.txt" }
             it "uses the full given path anyway" do
               expect(Guard::RSpec::RSpecProcess).to receive(:new).
-                with(anything, results_file).and_return(process)
+                with(anything, results_file, options).and_return(process)
               runner.run(paths)
             end
           end
@@ -296,8 +296,9 @@ RSpec.describe Guard::RSpec::Runner do
     context "with no custom results file" do
       let(:options) { { cmd: "rspec" } }
       it "uses the default" do
+        expected_params = [anything, %r{/tmp/rspec_guard_result$}, options]
         expect(Guard::RSpec::RSpecProcess).to receive(:new).
-          with(anything, %r{/tmp/rspec_guard_result$}).and_return(process)
+          with(*expected_params).and_return(process)
         runner.run(paths)
       end
     end


### PR DESCRIPTION
This is designed based on @e2's suggestion in #369. Bundler deprecated `with_clean_env` in 1.12.x and has stopped working for me. This adds the configuration of which method to use when executing the rspec cmd. The new default with be to use `with_original_env` based on the deprecation notice: https://github.com/bundler/bundler/blob/v1.12.5/lib/bundler.rb#L208 

I'm wondering if this should include an upgrade message for anyone bumping to this version.