### PR TITLE
update README from Guard documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add the gem to your Gemfile (inside development group):
 Add guard definition to your Guardfile by running this command:
 
 ```
-$ guard init rspec
+$ bundle exec guard init rspec
 ```
 
 ## Installing with beta versions of RSpec
@@ -36,7 +36,7 @@ gem 'guard-rspec, '~> 4.7`
 ```
 
 and for Rails projects this also means adding:
-  
+
 ```ruby
 gem 'rspec-rails', '= 3.5.0.beta3'
 ```


### PR DESCRIPTION
Using the README's suggested `guard init rspec` command resulted in "Warning: you have a Gemfile, but you're not using bundler or RUBYGEMS_GEMDEPS"

[Guard's documentation ](https://github.com/guard/guard#installation)states "It's important that you always run Guard through Bundler to avoid errors."

[Similar issue on StackOverflow.](http://stackoverflow.com/questions/33052593/warning-regarding-not-using-bundler-when-running-guard-init)