### PR TITLE
Fix when RSpec exits by segmentation fault.

### DIFF
--- a/lib/guard/rspec/rspec_process.rb
+++ b/lib/guard/rspec/rspec_process.rb
@@ -32,8 +32,8 @@ module Guard
           Compat::UI.debug(format(msg, command, exit_code.inspect))
 
           unless [0, Command::FAILURE_EXIT_CODE].include?(exit_code)
-            msg = "Failed: %s (exit code: %d)"
-            raise Failure, format(msg, command.inspect, exit_code)
+            msg = "Failed: %s (exit code: %s)"
+            raise Failure, format(msg, command.inspect, exit_code.inspect)
           end
           exit_code
         end

--- a/spec/lib/guard/rspec/rspec_process_spec.rb
+++ b/spec/lib/guard/rspec/rspec_process_spec.rb
@@ -52,6 +52,15 @@ RSpec.describe Guard::RSpec::RSpecProcess do
       end
     end
 
+    context "without any exit code" do
+      let(:exit_code) { nil }
+
+      it "fails" do
+        expect { subject }.
+          to raise_error(Guard::RSpec::RSpecProcess::Failure, /Failed: /)
+      end
+    end
+
     context "with the failure code for normal test failures" do
       let(:exit_code) { Guard::RSpec::Command::FAILURE_EXIT_CODE }
 


### PR DESCRIPTION
Problem
---------

When exit code of RSpec is `nil`, `rspec-guard` crash.

`Process:Status#exitcode`  is likely to return a `nil`(e.g. segmentation fault). 
http://ruby-doc.org/core-2.3.0/Process/Status.html#method-i-exitstatus

Reproduce
-------

Sorry, I could not  create a minimal repro....


```
$ git clone https://github.com/pocke/rebirth
$ cd rebirth
$ git checkout a17a77c50a967f08999c1fc547ee59e59145df3c
$ bundle install
$ bundle exec guard
[1] guard(main)>  all
23:57:54 - ERROR - Guard::RSpec failed to achieve its <run_all>, exception was:
> [#f4335484be65] TypeError: can't convert nil into Integer
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-rspec-4.7.2/lib/guard/rspec/rspec_process.rb:36:in `format'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-rspec-4.7.2/lib/guard/rspec/rspec_process.rb:36:in `block in _run'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-rspec-4.7.2/lib/guard/rspec/rspec_process.rb:76:in `block in _with_desired_bundler_env'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/bundler-1.12.5/lib/bundler.rb:233:in `block in with_original_env'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/bundler-1.12.5/lib/bundler.rb:447:in `with_env'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/bundler-1.12.5/lib/bundler.rb:233:in `with_original_env'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-rspec-4.7.2/lib/guard/rspec/rspec_process.rb:76:in `_with_desired_bundler_env'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-rspec-4.7.2/lib/guard/rspec/rspec_process.rb:28:in `_run'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-rspec-4.7.2/lib/guard/rspec/rspec_process.rb:17:in `initialize'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-rspec-4.7.2/lib/guard/rspec/runner.rb:65:in `new'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-rspec-4.7.2/lib/guard/rspec/runner.rb:65:in `_really_run'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-rspec-4.7.2/lib/guard/rspec/runner.rb:54:in `_run'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-rspec-4.7.2/lib/guard/rspec/runner.rb:31:in `run_all'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-rspec-4.7.2/lib/guard/rspec.rb:33:in `block in run_all'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-rspec-4.7.2/lib/guard/rspec.rb:48:in `_throw_if_failed'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-rspec-4.7.2/lib/guard/rspec.rb:33:in `run_all'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-2.14.0/lib/guard/runner.rb:82:in `block in _supervise'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-2.14.0/lib/guard/runner.rb:79:in `catch'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-2.14.0/lib/guard/runner.rb:79:in `_supervise'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-2.14.0/lib/guard/runner.rb:22:in `block (3 levels) in run'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-2.14.0/lib/guard/runner.rb:119:in `block (2 levels) in _run_group_plugins'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-2.14.0/lib/guard/runner.rb:117:in `each'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-2.14.0/lib/guard/runner.rb:117:in `block in _run_group_plugins'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-2.14.0/lib/guard/runner.rb:116:in `catch'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-2.14.0/lib/guard/runner.rb:116:in `_run_group_plugins'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-2.14.0/lib/guard/runner.rb:21:in `block (2 levels) in run'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-2.14.0/lib/guard/runner.rb:20:in `each'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-2.14.0/lib/guard/runner.rb:20:in `block in run'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/lumberjack-1.0.10/lib/lumberjack.rb:32:in `unit_of_work'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-2.14.0/lib/guard/runner.rb:18:in `run'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-2.14.0/lib/guard/commander.rb:82:in `run_all'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-2.14.0/lib/guard/internals/queue.rb:43:in `block in _run_actions'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-2.14.0/lib/guard/internals/queue.rb:38:in `each'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-2.14.0/lib/guard/internals/queue.rb:38:in `_run_actions'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-2.14.0/lib/guard/internals/queue.rb:22:in `process'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-2.14.0/lib/guard/commander.rb:43:in `start'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-2.14.0/lib/guard/cli/environments/valid.rb:16:in `start_guard'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-2.14.0/lib/guard/cli.rb:122:in `start'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-2.14.0/lib/guard/aruba_adapter.rb:32:in `execute'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-2.14.0/lib/guard/aruba_adapter.rb:19:in `execute!'
> [#f4335484be65] /home/pocke/.gem/ruby/2.3.0/gems/guard-2.14.0/bin/_guard-core:11:in `<main>'
23:57:54 - INFO - Guard::RSpec has just been fired
```