### PR TITLE
Add standard Rails rake task watcher

### DIFF
--- a/lib/guard/rspec/dsl.rb
+++ b/lib/guard/rspec/dsl.rb
@@ -47,6 +47,12 @@ module Guard
         @rails ||= _build_rails_rules(_view_extensions(options) * "|")
       end
 
+      def rake
+        @rake ||= OpenStruct.new.tap do |rake|
+          rake.rake_files = %r{^(lib/.+)\.rake}
+        end
+      end
+
       private
 
       def _view_extensions(options)

--- a/lib/guard/rspec/templates/Guardfile
+++ b/lib/guard/rspec/templates/Guardfile
@@ -50,4 +50,7 @@ guard :rspec, cmd: "bundle exec rspec" do
   watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|
     Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
   end
+
+  # Rake tasks
+  dsl.watch_spec_files_for(dsl.rake.rake_files)
 end


### PR DESCRIPTION
This will allow guard to watch something like `lib/task/foo.rake` and automatically run `spec/lib/tasks/foo_spec.rb` which is the standard locations for these in Rails