### PR TITLE
Fix already initialized constant for TEMPORARY_FILE_PATH

### DIFF
--- a/lib/guard/rspec_defaults.rb
+++ b/lib/guard/rspec_defaults.rb
@@ -1,5 +1,5 @@
 module Guard
   class RSpecDefaults
-    TEMPORARY_FILE_PATH = "tmp/rspec_guard_result".freeze
+    TEMPORARY_FILE_PATH ||= "tmp/rspec_guard_result".freeze
   end
 end


### PR DESCRIPTION
Running Guard RSpec with a `bundle exec rspec` command throws the warning
`already initialized constant Guard::RSpecDefaults::TEMPORARY_FILE_PATH`. This
commit simply checks whether or not `TEMPORARY_FILE_PATH` is already initialized
and only assigns a value to it if it's not.