### PR TITLE
Notify user of error and that examples are not run

### DIFF
--- a/lib/guard/rspec/notifier.rb
+++ b/lib/guard/rspec/notifier.rb
@@ -18,9 +18,9 @@ module Guard
                                  priority: priority)
       end
 
-      def notify_failure
+      def notify_failure(failure_message = 'Failed')
         return unless options[:notification]
-        Guard::Compat::UI.notify("Failed",
+        Guard::Compat::UI.notify(failure_message,
                                  title: @options[:title],
                                  image: :failed,
                                  priority: 2)

--- a/lib/guard/rspec/rspec_process.rb
+++ b/lib/guard/rspec/rspec_process.rb
@@ -22,6 +22,13 @@ module Guard
         exit_code.zero?
       end
 
+      # Returns true if there is an error AND examples are not run.
+      def error_and_examples_not_run?
+        error = "error occurred outside of examples"
+        summary_regexp = /0 examples, 0 failures( \((\d+) #{error}\))?/
+        !!results.summary.match(summary_regexp)
+      end
+
       private
 
       def _run

--- a/lib/guard/rspec/runner.rb
+++ b/lib/guard/rspec/runner.rb
@@ -64,12 +64,18 @@ module Guard
 
         process = RSpecProcess.new(cmd, file, options)
         results = process.results
-
         inspector.failed(results.failed_paths)
-        notifier.notify(results.summary)
-        _open_launchy
 
         all_green = process.all_green?
+
+        # Notify user of error and that examples are not run.
+        if process.error_and_examples_not_run?
+          notifier.notify_failure('Error/s occurred and examples are not run.')
+        else
+          notifier.notify(results.summary)
+        end
+
+        _open_launchy
         return yield all_green if block_given?
         all_green
       end

--- a/spec/lib/guard/rspec/rspec_process_spec.rb
+++ b/spec/lib/guard/rspec/rspec_process_spec.rb
@@ -64,11 +64,18 @@ RSpec.describe Guard::RSpec::RSpecProcess do
     context "with the failure code for normal test failures" do
       let(:exit_code) { Guard::RSpec::Command::FAILURE_EXIT_CODE }
 
+      before do
+        summary = '2 examples, 1 failure'
+        allow(results).to receive(:summary).and_return(summary)
+      end
+
       it "fails" do
         expect { subject }.to_not raise_error
       end
 
       it { is_expected.to_not be_all_green }
+
+      it { is_expected.to_not be_error_and_examples_not_run }
     end
 
     context "with no failures" do
@@ -147,6 +154,19 @@ RSpec.describe Guard::RSpec::RSpecProcess do
         expect(Bundler).to receive(:with_original_env)
         subject
       end
+    end
+
+    context "with error outside examples" do
+      let(:exit_code) { 2 }
+
+      before do
+        summary = '0 examples, 0 failures, 1 error occurred outside of examples'
+        allow(results).to receive(:summary).and_return(summary)
+      end
+
+      it { is_expected.to_not be_all_green }
+
+      it { is_expected.to be_error_and_examples_not_run }
     end
   end
 end

--- a/spec/lib/guard/rspec/runner_spec.rb
+++ b/spec/lib/guard/rspec/runner_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Guard::RSpec::Runner do
     allow(results).to receive(:summary).and_return("Summary")
     allow(results).to receive(:failed_paths).and_return([])
 
+    allow(process).to receive(:error_and_examples_not_run?).and_return(false)
     allow(Guard::RSpec::RSpecProcess).to receive(:new).and_return(process)
     allow(process).to receive(:all_green?).and_return(true)
     allow(process).to receive(:results).and_return(results)
@@ -336,6 +337,16 @@ RSpec.describe Guard::RSpec::Runner do
         and_raise(Guard::RSpec::RSpecProcess::Failure, /Failed: /)
 
       expect(notifier).to receive(:notify_failure)
+      runner.run(paths)
+    end
+
+    it "notifies that examples are not run" do
+      allow(process).to receive(:all_green?).and_return(false)
+      allow(process).to receive(:error_and_examples_not_run?).and_return(true)
+
+      expect(notifier).to receive(:notify_failure)
+        .with(%r{Error\/s occurred and examples are not run.})
+
       runner.run(paths)
     end
 


### PR DESCRIPTION
Fixes #398, now user is correctly notified of error and that examples are not run.

### Before
![before](https://user-images.githubusercontent.com/1292222/27937494-0fc2212c-62ea-11e7-8c32-3d308b0264b6.png)

### After
![after](https://user-images.githubusercontent.com/1292222/27937501-18186e6c-62ea-11e7-9e83-ff3dcd2d0300.png)

Please review, thanks!