### PR TITLE
CI against Ruby 2.2.9/2.3.6/2.4.3/2.5.0/JRuby 9.1.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
 language: ruby
 bundler_args: --without=tool development
 rvm:
-  - 2.2.5
-  - 2.3.1
-  - jruby-9.1.1.0
+  - 2.2.9
+  - 2.3.6
+  - 2.4.3
+  - 2.5.0
+  - jruby-9.1.16.0
 gemfile:
   - gemfiles/Gemfile.rspec-2.99
   - gemfiles/Gemfile.rspec-3.4
 matrix:
   allow_failures:
-    - rvm: jruby-9.1.1.0
+    - rvm: jruby-9.1.16.0
 sudo: false
 cache: bundler

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Guard::RSpec allows to automatically & intelligently launch specs when files are modified.
 
 * Compatible with RSpec >2.99 & 3
-* Tested against Ruby 2.2.x, JRuby 9.0.5.0 ~~and Rubinius~~.
+* Tested against Ruby 2.2.x, 2.3.x, 2.4.x, 2.5.x, JRuby 9.1.16.0 ~~and Rubinius~~.
 
 ## Install
 


### PR DESCRIPTION
Ruby 2.2.9/2.3.6/2.4.3/2.5.0/JRuby 9.1.16.0 has been released. And update README.

https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-2-9-released/
https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-3-6-released/
https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-4-3-released/
https://www.ruby-lang.org/en/news/2017/12/25/ruby-2-5-0-released/
http://jruby.org/2018/02/21/jruby-9-1-16-0