### PR TITLE
fix: use long arguments when calling rspec

### DIFF
--- a/lib/guard/rspec/command.rb
+++ b/lib/guard/rspec/command.rb
@@ -64,7 +64,7 @@ module Guard
 
       def _guard_formatter
         dir = Pathname.new(__FILE__).dirname.dirname
-        "-r #{dir + 'rspec_formatter.rb'} -f Guard::RSpecFormatter"
+        "--require #{dir + 'rspec_formatter.rb'} --format Guard::RSpecFormatter"
       end
     end
   end


### PR DESCRIPTION
This adds a fix adding long arguments when calling the underlying `rspec` command with the custom formatter.

This supports a wider range of usecases, like using a `.rspec` file.
These long arguments are backwards compatible with their shorter `-f` and
`-r` cousins. Those short arguments did not seem to work well when
specifying long arguments elsewhere.

`rake test:all_versions` passed ✅ 