### PR TITLE
Run on additions, not just modifications

### DIFF
--- a/lib/guard/rspec.rb
+++ b/lib/guard/rspec.rb
@@ -42,6 +42,8 @@ module Guard
       _throw_if_failed { runner.run(paths) }
     end
 
+    alias run_on_additions run_on_modifications
+
     private
 
     def _throw_if_failed

--- a/spec/lib/guard/rspec_spec.rb
+++ b/spec/lib/guard/rspec_spec.rb
@@ -88,4 +88,23 @@ RSpec.describe Guard::RSpec do
       plugin.run_on_modifications(paths)
     end
   end
+
+  describe "#run_on_additions" do
+    let(:paths) { %w[path1 path2] }
+    it "runs all specs via runner" do
+      expect(runner).to receive(:run).with(paths) { true }
+      plugin.run_on_additions(paths)
+    end
+
+    it "does nothing if paths empty" do
+      expect(runner).to_not receive(:run)
+      plugin.run_on_additions([])
+    end
+
+    it "throws task_has_failed if runner return false" do
+      allow(runner).to receive(:run) { false }
+      expect(plugin).to receive(:throw).with(:task_has_failed)
+      plugin.run_on_additions(paths)
+    end
+  end
 end


### PR DESCRIPTION
Some platforms (notably years-broken Docker Desktop) don't reliably notify of file modifications. It's caused a problem that guard-rspec is one of the few guards that does not run on file additions.

I haven't been able to find a reason that guard-rspec doesn't run on additions. In #391 it's discussed without any detractors.

There seems to be no downside to running on both file additions as well as modifications. For those running on macOS with Docker Desktop and listener, it seems to be necessary.

---

A workaround I've seen is adding the following to the `Guardfile`: `Guard::RSpec.class_eval { alias_method :run_on_additions, :run_on_modifications }`
But I would rather not continue to have to work around this shortcoming, especially when the fix seems to have no downside.
