### PR TITLE
Add convenience Ruby files regexes to DSL

### DIFF
--- a/lib/guard/rspec/dsl.rb
+++ b/lib/guard/rspec/dsl.rb
@@ -40,7 +40,7 @@ module Guard
         @ruby ||= OpenStruct.new.tap do |ruby|
           ruby.lib_files = %r{^(lib/.+)\.rb$}
           ruby.root_files = %r{^([^\/]+).rb$}
-          ruby.all_ruby_files = %r{^(.+).rb$}
+          ruby.all_ruby_files = /^(.+).rb$/
         end
       end
 

--- a/lib/guard/rspec/dsl.rb
+++ b/lib/guard/rspec/dsl.rb
@@ -39,6 +39,8 @@ module Guard
         # Ruby apps
         @ruby ||= OpenStruct.new.tap do |ruby|
           ruby.lib_files = %r{^(lib/.+)\.rb$}
+          ruby.root_files = %r{^([^\/]+).rb$}
+          ruby.all_ruby_files = %r{^(.+).rb$}
         end
       end
 


### PR DESCRIPTION
Sometimes you may want to work on ruby files in the root folder or with an arbitrary structure (not necessarily in the `lib/` folder).

This just adds those cases to the DSL, for convenience sake.

Example usage:

```ruby
  require "guard/rspec/dsl"
  dsl = Guard::RSpec::Dsl.new(self)

  # This is similar to the current `ruby.lib_files`
  # Ruby files
  ruby = dsl.ruby
  dsl.watch_spec_files_for(ruby.all_ruby_files)
  # Or
  dsl.watch_spec_files_for(ruby.root_files) 
```

I looked for DSL specs, but didn't find any. If there are, please point me in their direction and I'll update them.